### PR TITLE
Fix building with libpng 1.5

### DIFF
--- a/src/IMG_savepng.cpp
+++ b/src/IMG_savepng.cpp
@@ -27,6 +27,7 @@
 
 #ifdef IMPLEMENT_SAVE_PNG
 #include <png.h>
+#include <zlib.h>
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
The png.h header no longer internally includes zlib.h, so it should be included explicitly.
