### PR TITLE
Toshiba AC100 Tegra2 Linux changes

### DIFF
--- a/Makefile.ac100
+++ b/Makefile.ac100
@@ -1,0 +1,59 @@
+PREFIX	= /usr/local
+TOOLS	= bin
+
+INCLUDE = /usr/include
+LIBRARY = /usr/lib
+
+CC = gcc
+CXX = g++
+
+TEGRA = -mcpu=cortex-a9 -ftree-vectorize -mfloat-abi=soft -ffast-math -fsingle-precision-constant -fno-inline-functions
+OPT = -O2 $(TEGRA) -DTARGET_TEGRA -DSDL_VIDEO_OPENGL_ES -DGLdouble=GLfloat -DSDL_GL_SwapBuffers=EGL_SwapBuffers
+
+include Makefile.common
+
+extra_objects = eglport-tegra.o
+
+%.o : src/%.cpp
+	$(CXX) -DIMPLEMENT_SAVE_PNG -g $(OPT) -I$(INCLUDE) -I$(INCLUDE)/SDL -D_GNU_SOURCE=1 -D_REENTRANT -Wnon-virtual-dtor -Wreturn-type -fthreadsafe-statics -c $<
+
+%.o : src/%.c
+	$(CC) -DIMPLEMENT_SAVE_PNG -fno-inline-functions -g $(OPT) -I$(INCLUDE) -I$(INCLUDE)/SDL -D_GNU_SOURCE=1 -D_REENTRANT -Wreturn-type -c $<
+
+game: $(objects) $(extra_objects)
+	$(CXX) -s $(OPT) -L$(LIBRARY) -Wl,-rpath=$(LIBRARY) -L/usr/lib/nvidia-tegra -D_GNU_SOURCE=1 -D_REENTRANT -Wnon-virtual-dtor -Wreturn-type $(objects) $(extra_objects) -lSDLmain -lSDL -lGLESv1_CM -lEGL -lX11 -lXau -lXdmcp  -lSDL_image -lSDL_ttf -lSDL_mixer -lpng12 -ljpeg -lz -lfreetype -lmad -ltiff -lboost_regex-mt -lboost_system-mt -fthreadsafe-statics -o game
+
+server: $(server_objects)
+	$(CXX) -fno-inline-functions -g $(OPT) -L/sw/lib -D_GNU_SOURCE=1 -D_REENTRANT -Wnon-virtual-dtor -Wreturn-type -L/usr/lib `sdl-config --libs` -lSDLmain -lSDL -lGL -lGLU -lSDL_image -lSDL_ttf -lSDL_mixer -lboost_regex-mt -lboost_system-mt -lboost_thread-mt -lboost_iostreams-mt -fthreadsafe-statics $(server_objects) -o server
+
+formula_test: $(formula_test_objects)
+	$(CXX) -O2 -g -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DUNIT_TEST_FORMULA -Wnon-virtual-dtor -Wreturn-type -L/usr/lib -lSDL -lGL -lGLU -lSDL_image -lSDL_ttf -lSDL_mixer -lboost_regex src/formula.cpp $(formula_test_objects) -o test
+
+wml_modify_test: $(wml_modify_test_objects)
+	$(CXX) -O2 -g -Isrc/ -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DUNIT_TEST_WML_MODIFY -Wnon-virtual-dtor -Wreturn-type -L/usr/lib -lboost_regex src/wml_modify.cpp $(wml_modify_test_objects) -o test
+
+wml_schema_test: $(wml_schema_test_objects)
+	$(CXX) -O2 -g -framework Cocoa -I/usr/local/include/boost-1_34 -I/sw/include/SDL -Isrc/ -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DUNIT_TEST_WML_SCHEMA -Wnon-virtual-dtor -Wreturn-type -L/usr/lib -lboost_regex src/wml_schema.cpp $(wml_schema_test_objects) -o test
+
+update-pot:
+	utils/make-pot.sh > po/frogatto.pot
+
+%.po: po/frogatto.pot
+	msgmerge $@ po/frogatto.pot -o $@.part
+	mv $@.part $@
+
+LINGUAS=de es fr it pt_BR ru zh_CN
+
+update-po:
+	(for lang in ${LINGUAS}; do \
+		${MAKE} po/$$lang.po ; \
+	done)
+
+update-mo:
+	(for lang in ${LINGUAS}; do \
+		mkdir -p locale/$$lang/LC_MESSAGES ; \
+		msgfmt po/$$lang.po -o locale/$$lang/LC_MESSAGES/frogatto.mo ; \
+	done)
+
+clean:
+	rm -f *.o game

--- a/src/IMG_savepng.cpp
+++ b/src/IMG_savepng.cpp
@@ -32,7 +32,7 @@
 
 #include <stdlib.h>
 #include <SDL/SDL.h>
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/blur.cpp
+++ b/src/blur.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/border_widget.cpp
+++ b/src/border_widget.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/color_utils.cpp
+++ b/src/color_utils.cpp
@@ -1,7 +1,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/color_utils.hpp
+++ b/src/color_utils.hpp
@@ -2,7 +2,7 @@
 #define COLOR_UTILS_HPP_INCLUDED
 
 #include "SDL.h"
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/draw_scene.cpp
+++ b/src/draw_scene.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #ifdef TARGET_PANDORA
 #include <GLES/glues.h>

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #ifdef TARGET_PANDORA
 #include <GLES/glues.h>

--- a/src/eglport-tegra.c
+++ b/src/eglport-tegra.c
@@ -1,0 +1,225 @@
+/**
+*
+* eglport-tegra.c
+* Copyright (C) 2011 Scott Smith, Joni Valtanen
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "eglport.h"
+
+#define EGLNativeWindowType NativeWindowType
+#define EGLNativeDisplayType NativeDisplayType
+
+EGLDisplay g_eglDisplay = 0;
+EGLConfig g_eglConfig = 0;
+EGLContext g_eglContext = 0;
+EGLSurface g_eglSurface = 0;
+
+#define g_totalConfigsIn 20
+int g_totalConfigsFound = 0;
+EGLConfig g_allConfigs[g_totalConfigsIn];
+Display *g_x11Display = NULL;
+
+
+/*======================================================
+ * Kill off any opengl specific details
+  ====================================================*/
+void EGL_Destroy()
+{
+    if( g_eglSurface || g_eglContext || g_eglDisplay )
+    {
+        eglMakeCurrent(g_eglDisplay, NULL, NULL, EGL_NO_CONTEXT);
+        eglDestroyContext(g_eglDisplay, g_eglContext);
+        eglDestroySurface(g_eglDisplay, g_eglSurface);
+        eglTerminate(g_eglDisplay);
+    }
+
+    g_eglSurface = 0;
+    g_eglContext = 0;
+    g_eglDisplay = 0;
+
+    if (g_x11Display)
+        XCloseDisplay(g_x11Display);
+
+    g_x11Display = NULL;
+
+    printf( "EGL Closed\n");
+}
+
+/*===========================================================
+Setup EGL context and surface
+===========================================================*/
+int EGL_Init( void )
+{
+    EGL_Open ();
+    FindAppropriateEGLConfigs();
+
+    int configIndex = 0;
+    printf( "Config %d\n", configIndex );
+
+	if (!ConfigureEGL(g_allConfigs[configIndex]))
+	{
+		TestEGLError();
+		fprintf(stderr, "ERROR: Unable to initialise EGL. See previous error.\n");
+		return 1;
+	}
+
+    return 0;
+}
+
+/*===========================================================
+Swap EGL buffers and update the display
+===========================================================*/
+void EGL_SwapBuffers( void )
+{
+	eglSwapBuffers(g_eglDisplay, g_eglSurface);
+}
+
+
+/*========================================================
+ *  Init base EGL
+ * ======================================================*/
+int EGL_Open( void )
+{
+    // use EGL to initialise GLES
+    printf( "EGL Open display\n" );
+    g_x11Display = XOpenDisplay(NULL);
+    if (!g_x11Display)
+    {
+        fprintf(stderr, "ERROR: unable to get display!\n");
+        return 0;
+    }
+
+    printf( "EGL Get display\n" );
+    g_eglDisplay = eglGetDisplay((EGLNativeDisplayType)g_x11Display);
+    if (g_eglDisplay == EGL_NO_DISPLAY)
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to initialise EGL display.\n");
+        return 0;
+    }
+
+    // Initialise egl
+    printf( "EGL Init\n" );
+    if (!eglInitialize(g_eglDisplay, NULL, NULL))
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to initialise EGL display.\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+/*===========================================================
+Initialise OpenGL settings
+===========================================================*/
+int ConfigureEGL(EGLConfig config)
+{
+    // Cleanup in case of a reset
+    if( g_eglSurface || g_eglContext || g_eglDisplay )
+    {
+        eglMakeCurrent(g_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        eglDestroyContext(g_eglDisplay, g_eglContext);
+        eglDestroySurface(g_eglDisplay, g_eglSurface);
+    }
+
+    // Bind GLES and create the context
+    printf( "EGL Bind\n" );
+    eglBindAPI(EGL_OPENGL_ES_API);
+	if (!TestEGLError() )
+	{
+		return 0;
+	}
+
+    printf( "EGL Create Context\n" );
+    g_eglContext = eglCreateContext(g_eglDisplay, config, EGL_NO_CONTEXT, NULL);
+    if (g_eglContext == EGL_NO_CONTEXT)
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to create GLES context!\n");
+        return 0;
+    }
+
+    // Get the SDL window handle
+    SDL_SysWMinfo sysInfo; //Will hold our Window information
+    SDL_VERSION(&sysInfo.version); //Set SDL version
+    if(SDL_GetWMInfo(&sysInfo) <= 0)
+    {
+        TestEGLError();
+        fprintf( stderr, "ERROR: Unable to get window handle\n");
+        return 0;
+    }
+
+    printf( "EGL Create window surface\n" );
+    g_eglSurface = eglCreateWindowSurface(g_eglDisplay, config, (EGLNativeWindowType)sysInfo.info.x11.window, 0);
+
+    if ( g_eglSurface == EGL_NO_SURFACE)
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to create EGL surface!\n");
+        return 0;
+    }
+
+    printf( "EGL Make Current\n" );
+    if (eglMakeCurrent(g_eglDisplay,  g_eglSurface,  g_eglSurface, g_eglContext) == EGL_FALSE)
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to make GLES context current\n");
+        return 0;
+    }
+
+    printf( "EGL Done\n" );
+    return 1;
+}
+
+/*=======================================================
+* Detect available video resolutions
+=======================================================*/
+int FindAppropriateEGLConfigs( void )
+{
+    static const EGLint s_configAttribs[] =
+    {
+          EGL_RED_SIZE,        1,
+          EGL_GREEN_SIZE,      1,
+          EGL_BLUE_SIZE,       1,
+          EGL_DEPTH_SIZE,      1,
+          EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
+          EGL_RENDERABLE_TYPE, 2,
+          EGL_NONE
+    };
+
+    if (eglChooseConfig(g_eglDisplay, s_configAttribs, g_allConfigs, g_totalConfigsIn, &g_totalConfigsFound) != EGL_TRUE || g_totalConfigsFound == 0)
+    {
+        TestEGLError();
+        fprintf(stderr, "ERROR: Unable to query for available configs.\n");
+        return 0;
+    }
+    fprintf(stderr, "Found %d available configs\n", g_totalConfigsFound);
+    return 1;
+}
+
+int TestEGLError( void )
+{
+	EGLint iErr = eglGetError();
+	while (iErr != EGL_SUCCESS)
+	{
+		printf("EGL failed (0x%x).\n", iErr);
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 #ifndef SDL_VIDEO_OPENGL_ES
 #include <GL/glew.h>
 #endif
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #ifdef TARGET_PANDORA
 #include <GLES/glues.h>
@@ -70,7 +70,7 @@
 #include "wml_utils.hpp"
 #include "wml_writer.hpp"
 
-#if defined(TARGET_PANDORA)
+#if defined(TARGET_PANDORA) | defined(TARGET_TEGRA)
 #include "eglport.h"
 #endif
 
@@ -332,10 +332,20 @@ extern "C" int main(int argc, char** argv)
     EGL_Init();
     preferences::init_oes();
 #else
+#if defined(TARGET_TEGRA)
+	//if (SDL_SetVideoMode(preferences::actual_screen_width(),preferences::actual_screen_height(),0,preferences::resizable() ? SDL_RESIZABLE : 0|preferences::fullscreen() ? SDL_FULLSCREEN : 0) == NULL) {
+	if (SDL_SetVideoMode(preferences::actual_screen_width(),preferences::actual_screen_height(),0,SDL_FULLSCREEN) == NULL) {
+		std::cerr << "could not set video mode\n";
+		return -1;
+	}
+    EGL_Init();
+    preferences::init_oes();
+#else
 	if (SDL_SetVideoMode(preferences::actual_screen_width(),preferences::actual_screen_height(),0,SDL_OPENGL|(preferences::resizable() ? SDL_RESIZABLE : 0)|(preferences::fullscreen() ? SDL_FULLSCREEN : 0)) == NULL) {
 		std::cerr << "could not set video mode\n";
 		return -1;
 	}
+#endif
 #endif
 #endif
 
@@ -521,7 +531,7 @@ extern "C" int main(int argc, char** argv)
 	} //end manager scope, make managers destruct before calling SDL_Quit
 
 //	controls::debug_dump_controls();
-#if defined(TARGET_PANDORA)
+#if defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
     EGL_Destroy();
 #endif
 
@@ -529,7 +539,7 @@ extern "C" int main(int argc, char** argv)
 	
 	preferences::save_preferences();
 	std::cerr << SDL_GetError() << "\n";
-#ifndef TARGET_OS_HARMATTAN
+#if !defined(TARGET_OS_HARMATTAN) && !defined(TARGET_TEGRA)
 	std::cerr << gluErrorString(glGetError()) << "\n";
 #endif
 	return 0;

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -108,17 +108,29 @@ namespace preferences {
 #ifndef PREFERENCES_PATH
 #define PREFERENCES_PATH "~/.frogatto/"
 #endif
+		bool screen_rotated_ = false;
+		
+		bool use_joystick_ = true;
+
+#if defined(TARGET_TEGRA)
+		int virtual_screen_width_ = 1024;
+		int virtual_screen_height_ = 600;
+		
+		int actual_screen_width_ = 1024;
+		int actual_screen_height_ = 600;
+	
+		bool load_compiled_ = true;
+		bool use_fbo_ = true;
+		bool use_bequ_ = true;
+#else
 		int virtual_screen_width_ = 800;
 		int virtual_screen_height_ = 600;
 		
 		int actual_screen_width_ = 800;
 		int actual_screen_height_ = 600;
-		
-		bool screen_rotated_ = false;
-		
-		bool use_joystick_ = true;
-
+	
 		bool load_compiled_ = false;
+#endif
 
 #if defined(TARGET_PANDORA)
         bool use_fbo_ = true;
@@ -333,7 +345,7 @@ namespace preferences {
 		load_compiled_ = value;
 	}
 	
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	bool use_fbo()
 	{
 		return use_fbo_;
@@ -601,7 +613,7 @@ namespace preferences {
 		return run_failing_unit_tests_;
 	}
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	PFNGLBLENDEQUATIONOESPROC           glBlendEquationOES;
 	PFNGLGENFRAMEBUFFERSOESPROC         glGenFramebuffersOES;
 	PFNGLBINDFRAMEBUFFEROESPROC         glBindFramebufferOES;

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <EGL/egl.h>
 #include <GLES/gl.h>
 #include <GLES/glext.h>
@@ -71,7 +71,7 @@ namespace preferences {
 
 	void set_load_compiled(bool value);
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 bool use_fbo();
 bool use_bequ();
 void set_fbo( bool value );
@@ -121,7 +121,7 @@ void set_bequ( bool value );
 		~editor_screen_size_scope();
 	};
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	void init_oes( void );
 	extern PFNGLBLENDEQUATIONOESPROC           glBlendEquationOES;
 	extern PFNGLGENFRAMEBUFFERSOESPROC         glGenFramebuffersOES;

--- a/src/raster.cpp
+++ b/src/raster.cpp
@@ -10,7 +10,7 @@
  
  See the COPYING file for more details.
  */
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #ifdef TARGET_PANDORA
 #include <GLES/glues.h>

--- a/src/raster_distortion.cpp
+++ b/src/raster_distortion.cpp
@@ -1,7 +1,7 @@
 #include <math.h>
 #include <stdlib.h>
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/raster_distortion.hpp
+++ b/src/raster_distortion.hpp
@@ -1,7 +1,7 @@
 #ifndef RASTER_DISTORTION_HPP_INCLUDED
 #define RASTER_DISTORTION_HPP_INCLUDED
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/rectangle_rotator.cpp
+++ b/src/rectangle_rotator.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1,4 +1,4 @@
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/surface_formula.hpp
+++ b/src/surface_formula.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -10,7 +10,7 @@
    See the COPYING file for more details.
 */
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #ifdef TARGET_PANDORA
 #include <GLES/glues.h>

--- a/src/texture.hpp
+++ b/src/texture.hpp
@@ -18,7 +18,7 @@
 #include <boost/shared_ptr.hpp>
 #include <vector>
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/texture_frame_buffer.cpp
+++ b/src/texture_frame_buffer.cpp
@@ -8,7 +8,7 @@
 #include "texture.hpp"
 #include "texture_frame_buffer.hpp"
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <EGL/egl.h>
 #include <GLES/gl.h>
 #include <GLES/glext.h>
@@ -19,7 +19,7 @@
 #endif
 
 //define macros that make it easy to make the OpenGL calls in this file.
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_OS_IPHONE) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_OS_IPHONE) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #define EXT_CALL(call) call##OES
 #define EXT_MACRO(macro) macro##_OES
 #elif defined(__APPLE__)
@@ -54,7 +54,7 @@ void init(int buffer_width, int buffer_height)
 	frame_buffer_texture_width = buffer_width;
 	frame_buffer_texture_height = buffer_height;
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	if (glGenFramebuffersOES        != NULL &&
 		glBindFramebufferOES        != NULL &&
 		glFramebufferTexture2DOES   != NULL &&
@@ -78,8 +78,9 @@ void init(int buffer_width, int buffer_height)
 #endif
 	fprintf(stderr, "FRAME BUFFER OBJECT IS SUPPORTED\n");
 
+#ifndef TARGET_TEGRA
 	glGetIntegerv(EXT_MACRO(GL_FRAMEBUFFER_BINDING), &video_framebuffer_id);
-
+#endif
 	ASSERT_EQ(glGetError(), GL_NO_ERROR);
 	glGenTextures(1, &texture_id);
 	glBindTexture(GL_TEXTURE_2D, texture_id);

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -20,7 +20,7 @@
 #include "wml_utils.hpp"
 #include "color_utils.hpp"
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <EGL/egl.h>
 #include <GLES/gl.h>
 #include <GLES/glext.h>
@@ -171,7 +171,7 @@ bool water::draw_area(const water::area& a, int x, int y, int w, int h) const
 	unsigned char water_color[] = {a.color_[0], a.color_[1], a.color_[2], a.color_[3]};
 	
 	glBlendFunc(GL_ONE, GL_ONE);
-	#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+	#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	if (glBlendEquationOES)
 		glBlendEquationOES(GL_FUNC_REVERSE_SUBTRACT_OES);
 	#elif defined(GL_OES_blend_subtract)
@@ -198,11 +198,15 @@ bool water::draw_area(const water::area& a, int x, int y, int w, int h) const
 		waterline_rect.x, underwater_rect.y + underwater_rect.h,
 		waterline_rect.x + waterline_rect.w, underwater_rect.y + underwater_rect.h
 	};
-	
+
+#if defined(TARGET_TEGRA)	
+	glColor4ub (0,0,0,255); // tegra linux drivers have some issues
+#else
 	glColor4ub(water_color[0], water_color[1], water_color[2], water_color[3]);
+#endif	
 	glVertexPointer(2, GL_FLOAT, 0, vertices);
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, sizeof(vertices)/sizeof(GLfloat)/2);
-	#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+	#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 	if (glBlendEquationOES)
 		glBlendEquationOES(GL_FUNC_ADD_OES);
 	#elif defined(GL_OES_blend_subtract)

--- a/src/water_particle_system.hpp
+++ b/src/water_particle_system.hpp
@@ -1,7 +1,7 @@
 #ifndef water_PARTICLE_SYSTEM_H
 #define water_PARTICLE_SYSTEM_H
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>

--- a/src/weather_particle_system.hpp
+++ b/src/weather_particle_system.hpp
@@ -1,7 +1,7 @@
 #ifndef WEATHER_PARTICLE_SYSTEM_HPP_INCLUDED
 #define WEATHER_PARTICLE_SYSTEM_HPP_INCLUDED
 
-#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA)
+#if defined(TARGET_OS_HARMATTAN) || defined(TARGET_PANDORA) || defined(TARGET_TEGRA)
 #include <GLES/gl.h>
 #else
 #include <GL/gl.h>


### PR DESCRIPTION
Changes makes Frogatto to build with Toshiba AC100 Linux. AC100 uses NVidia Tegra2 ARM SOC.

Two new files are added. Makefile.ac100 and eglport-tegra.c. Build is based on the Pandora build and tested with Ubuntu Oneiric. Changes should also work with any other Tegra2 Linux machine/Linux distribution with minimal or no [makefile]changes.

Game use fullscreen as default, because of 1024x600-desktop. 480 window height is too small to Frogatto and 600 is too big for Unity. Something between might work, but I decided to use fs instead.

Changes are in the one commit. Even if it conflicts merge should be quite trivial. Whole patch is about finding good preference values and right EGL setup.

I think there should be some common define to Pandora and Harmattan (and Tegra). Look diff and you figure out why. I didn't add that because I didn't want to mess with other platforms, yet.
