### PR TITLE
Made assert.cpp compile more easily in Visual Studio

### DIFF
--- a/src/asserts.cpp
+++ b/src/asserts.cpp
@@ -7,7 +7,7 @@
 #include "variant.hpp"
 
 #if defined(_WINDOWS)
-#include "SDL/SDL_syswm.h"
+#include "SDL_syswm.h"
 #endif
 
 void report_assert_msg(const std::string& m)


### PR DESCRIPTION
```
... if compiling on Windows. The binary distribution of SDL development libraries does not come with an /include/SDL folder, only an /include folder.
```

I've been having some difficulties getting my build environment to work under Visual Studio 2010, but it seemed somewhat odd that this one source file require one SDL header to be in a folder called SDL, when pre-built SDL for Visual Studio does not come distributed that way.
