### PR TITLE
resubmit: Changed #include for an SDL library so that it is not preceded by "SDL/"...

### DIFF
--- a/src/asserts.cpp
+++ b/src/asserts.cpp
@@ -7,7 +7,7 @@
 #include "variant.hpp"
 
 #if defined(_WINDOWS)
-#include "SDL/SDL_syswm.h"
+#include "SDL_syswm.h"
 #endif
 
 void report_assert_msg(const std::string& m)


### PR DESCRIPTION
Thanks for reconsidering my idea. :-)
