### PR TITLE
Additional sdl headers included on windows

### DIFF
--- a/src/graphics.hpp
+++ b/src/graphics.hpp
@@ -22,7 +22,7 @@
 
 #endif
 
-#if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_IPHONE && !__MACOSX__ && !defined(__ANDROID__) && !defined(TARGET_BLACKBERRY)
+#if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_IPHONE && !__MACOSX__ && !defined(__ANDROID__) && !defined(TARGET_BLACKBERRY) && !defined(_WINDOWS)
 #include <SDL/SDL_mixer.h>
 #endif
 
@@ -30,11 +30,11 @@
 #include <GL/glew.h>
 #endif
 
-#if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_HARMATTAN && !TARGET_OS_IPHONE && !__MACOSX__ && !defined(__ANDROID__) && !defined(TARGET_BLACKBERRY)
+#if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_HARMATTAN && !TARGET_OS_IPHONE && !__MACOSX__ && !defined(__ANDROID__) && !defined(TARGET_BLACKBERRY) && !defined(_WINDOWS)
 #include <SDL/SDL_ttf.h>
 #endif
 
-#if __MACOSX__ || defined(__ANDROID__) || defined(TARGET_BLACKBERRY)
+#if __MACOSX__ || defined(__ANDROID__) || defined(TARGET_BLACKBERRY) || defined(_WINDOWS)
 #include <SDL_mixer.h>
 #include <SDL_ttf.h>
 #endif

--- a/src/surface_cache.cpp
+++ b/src/surface_cache.cpp
@@ -15,7 +15,7 @@
 #include "filesystem.hpp"
 #include "module.hpp"
 #include "surface_cache.hpp"
-#if defined(__MACOSX__) || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || defined(TARGET_BLACKBERRY)
+#if defined(__MACOSX__) || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || defined(TARGET_BLACKBERRY) || defined(_WINDOWS)
 	#include <SDL_image.h>
 #else	
 	#include <SDL/SDL_image.h>


### PR DESCRIPTION
Remember how I had to change an #include for Windows from #include "SDL\SDL.h" to #include "SDL.h", or something to that effect? I noticed that the external libraries we use SDL_mixer.h, SDL_image.h, and SDL_ttf.h all have the same problem: they require Windows maintainers to move include files from their default location.

For the sake of consistency, I submit for your consideration a commit that makes it so that on Windows headers are included from their default locations, just as they are on Mac OS X and iPhone.
