### PR TITLE
Split hittable.cfg into two files.

### DIFF
--- a/data/object_prototypes/base/hittable.cfg
+++ b/data/object_prototypes/base/hittable.cfg
@@ -1,289 +1,19 @@
+# This is the hittable script which Frogatto depends on. Code in this file
+# is specific to Frogatto.
+
 {
 id: "hittable",
-prototype: ["standard_values"],
-is_strict: true,
-collide_dimensions: ["player","~enemy","~hazard"],
+prototype: ["hittable_std"],
 
-mass: 5,
 properties: {
-#--------------------------  constants --------------------------#
-	team: "string :: 'evil'",
-	teams_which_wont_get_hurt_by_me: "[string] :: []",	//a special exemption; used on e.g. the shockwave airplane boss bomb, to keep it from killing the bridge
-	swallowable: "bool :: false",
-	is_a_flier: "bool :: false",
-	flinch_threshold: "int :: 3",
-	hurt_velocity_y: "int :: -400",
-	hurt_velocity_x: "int :: -200",
-	attack_knockback: "int :: 0",
-	attack_damage: "int :: 0",
-	attack_damage_to_player: "int :: 0",
-	damage_type: "string :: 'neutral'",  //options include fire, acid, energy
-	armor: "int :: 0",
-	posthit_invicibility_period: "int :: 0",
-	damage_cooldown: "int :: 0",
-	sourceless_damage_cooldown: "int :: 20",
-	points_value: "int :: 0",
-	
-	material_sound: "string :: 'default'",
-	
-	physical_size: "int :: 16",
-	is_player_body_part: "bool :: false",
-
-	taxonomy: "string :: 'neutral'",	//e.g. plant, bug, fish, etc.  Used for damage type reductions.
-	basic_type: "string :: me.type",
-	frogourmet_tag: "string :: me.basic_type",
-	thrown_type: "string :: me.basic_type",
-
-		#-- shot includes --#
-	deflectable_via_attacks: "bool :: if(team = 'player', false, true)",  
-	dies_upon_dealing_damage: "bool :: true",
-	is_a_shot: "bool :: false",
-	goes_through_enemy_shots: "bool :: false",
-	
-		#-- special flags for specific objects --#
-	affects_ethereal_block_triggers: "bool :: true",
-	
-#--------------------------  core behavior handlers --------------------------#	
-	get_hit_by: "def(obj hittable collide_with) -> commands execute(me, [
-						handle_special_damage_response(collide_with),
-	
-						if((collide_with.attack_damage > 0) and collide_with.hitpoints > 0 and collide_with.damage_cooldown < (level.cycle - time_last_hit),
-							[if((not is_invincible) and collide_with.attack_damage > armor,
-									[display_posthit_invincibility_flash_sequence(),
-									handle_flinch(collide_with),
-									handle_damage(collide_with),
-									set(time_last_hit, level.cycle),
-									])]),
-						
-						handle_knockback(collide_with)])",
-						
-	get_hit_sourceless: "def(string damage_type, int damage_amount) -> commands execute(me,  /*take damage and invoke the usual behavior, but without having a source object available to refer to.
-															This almost universally should be used for e.g. being stomped on, or other self-determined damage amounts (falling?).
-															It's also used for thrown damage because the throwee is dead and would (potentially) be a null reference by the time the latter collision was processed.*/
-						if((not is_invincible) and (damage_amount >= armor) and (sourceless_damage_cooldown < (level.cycle - time_last_hit)),
-								[display_posthit_invincibility_flash_sequence(),
-								handle_damage_sourceless(damage_type, damage_amount),
-								/* specifically skip flinching, because kitties don't do it.  TODO: Might be something to later reconsider. */
-								set(time_last_hit, level.cycle),
-								]))",
-
-#-------------------------- identifiers --------------------------#
-	
-	
-
-#-------------------------- generic helper functions --------------------------#
-	turn_towards_player: "commands :: if(not facing_towards_player, set(facing, direction_towards_player))", //highly likely to be overridden in other prototypes, so this is mostly virtual
-	direction_towards_player: "if(midpoint_x - level.player.midpoint_x > 0, -1, 1)",
-	facing_towards_player: "bool :: facing = if(level.player.midpoint_x < self.midpoint_x, -1, 1)",
-	
-	
-	attempt_animation: "def(string anim_name, string fallback_anim) -> commands execute(me, if(anim_name in available_animations, set(animation, anim_name), set(animation, fallback_anim)))",
-
-
-#-------------------------- behavior handlers --------------------------#
-# anims/movement
-	handle_special_damage_response: "def(obj hittable|null collide_with) -> commands null #virtual#", //meant for unique actions upon taking damage, like losing wings.  Also for special type-based behavior that happens regardless of damage amount (such as maybe a feathered creature having its feathers burned off and effectively turning into a different, flightless enemy type).
-	handle_flinch: "def(obj hittable collide_with) -> commands
-			execute(me, if(final_damage_amount(collide_with, collide_with.attack_damage) >= flinch_threshold, if(me.is_a_flier, cause_flinch(collide_with), if(is_standing, cause_flinch(collide_with))) ))",
-	cause_flinch: "def(obj hittable|null collide_with) -> commands execute(me, [
-			add(me.velocity_x,me.hurt_velocity_x * sign(me.midpoint_x - if(collide_with, collide_with.midpoint_x, 0))), 
-			add(me.velocity_y,me.hurt_velocity_y),
-			cause_hurt_anim(collide_with)
-			])",
-	cause_hurt_anim: "def(obj hittable|null collide_with) -> commands execute(me, if('hurt' in available_animations,set(me.animation, 'hurt')))",
-
-	player_damage_response: "def(string damage_type, int amount) -> commands null",	//player objects will always do special responses to damage (like making the screen flash), besides the built-in stuff
-
-	elastic_collision: "def( obj hittable the_other_object, {multiplier: decimal, constraint: {min: decimal, max: decimal}|null} params ) -> commands
-		([set(velocity_x, radius * cos(angle)), set(velocity_y, radius * sin(angle))]
-		where angle = lib.math.angle(the_other_object, me) where radius = if(params.constraint, lib.math.constrain(params.constraint.min, params.multiplier * velocity_magnitude , params.constraint.max), params.multiplier * velocity_magnitude) )  where velocity_magnitude = hypot(velocity_x,velocity_y)",
-	
-# damage
-	//meant for applying any kind of arithmetic to the raw damage amount, based on type.
-		//this is what you overload if you want to have an exception to the damage tables (i.e. for an unusual weakness; as opposed to a usual one for a given type)
-	handle_custom_damage_type_modifications: "def(string damage_type, int amount) -> int|null null #virtual#",  
-		//only overload this if you want to completely annul the damage tables for this object (i.e. for complete immunity to all but one damage type)
-	handle_damage_type_modifications: "def(string damage_type, int amount) -> int
-		if(handle_custom_damage_type_modifications(damage_type,amount) != null,  int <- handle_custom_damage_type_modifications(damage_type,amount),
-			if(uses_custom_damage_table, int(custom_damage_table[damage_type] * amount),
-				if(me.taxonomy in keys(damage_tables), int(damage_tables[me.taxonomy][damage_type] * amount), amount
-		)))", //the neutral case automatically falls through
-	
-	uses_custom_damage_table: "bool :: false",  //cheap trick:  if you just want something to take 100% damage from all damage types, you can use this without redefining the 'custom_damage_table', which happens to just have 100% as the value for everything.
-	
-	//meant for flat, type-agnostic reductions to ALL damage.
-	handle_base_damage_reductions: "def(int amount) -> int amount #virtual#",  
-	
-	final_damage_amount: "def(interface {damage_type: string} collide_with, int damage_amount) -> int if((damage_amount < armor) or me.is_invincible, 0, handle_damage_type_modifications(collide_with.damage_type, handle_base_damage_reductions( damage_amount )))",
-	will_be_dead: "def(int damage_amount) -> bool ((me.hitpoints - damage_amount) <= 0)",
-
-	
-	handle_damage_sourceless: "def(string damage_type, int amount) -> commands execute(me,[if(will_be_dead(dmg), handle_death({damage_type:damage_type})), add(me.hitpoints, -dmg), display_hurt_visuals({damage_type:damage_type},dmg), player_damage_response(damage_type,dmg)]) where dmg = final_damage_amount({damage_type:damage_type}, amount)",
-	handle_damage: "def(obj hittable collide_with) -> commands execute(me,[if(will_be_dead(dmg), handle_death(collide_with)), add(me.hitpoints, - dmg), display_hurt_visuals(collide_with,dmg),player_damage_response(collide_with.damage_type,dmg)]) where dmg = final_damage_amount(collide_with, attack_damage_amount) where attack_damage_amount = if((me is obj player_controlled) and collide_with.attack_damage_to_player, collide_with.attack_damage_to_player, collide_with.attack_damage)",
-
-	handle_knockback: "def(obj hittable collide_with) -> commands execute(me,add(velocity_x, behind_or_in_front * collide_with.attack_knockback) where behind_or_in_front = sign(me.mid_x - collide_with.mid_x) )",
-
-	custom_damage_table: "{neutral:decimal, fire:decimal, energy:decimal, acid:decimal, impact:decimal, lacerate:decimal} ::
-							{	neutral: 1.0,
-								fire: 1.0,
-								energy: 1.0,
-								acid: 1.0,
-								impact: 1.0,
-								lacerate: 1.0
-							}",
-
-	damage_tables: "{ string -> {neutral:decimal, fire:decimal, energy:decimal, acid:decimal, impact:decimal, lacerate:decimal} } ::
-						{	
-							'bug' : {		neutral: 1.0,
-											fire: 0.75,
-											energy: 1.0,
-											acid: 1.25,
-											impact: 2.0,
-											lacerate: 0.25
-									},
-							'plant' : {		neutral: 1.0,
-											fire: 1.0,
-											energy: 0.5,
-											acid: 0.25,
-											impact: 0.0,
-											lacerate: 0.5
-									},
-							'mushroom' : {	neutral: 1.0,
-											fire: 1.0,
-											energy: 1.5,
-											acid: 0.0,
-											impact: 0.0,
-											lacerate: 1.0
-									},
-							'stone' : {		neutral: 1.0,
-											fire: 0.0,
-											energy: 0.1,
-											acid: 2.0,
-											impact: 1.0,
-											lacerate: 0.0
-									},
-							'milgramen' : {	neutral: 1.0,
-											fire: 0.75,
-											energy: 1.0,
-											acid: 0.75,
-											impact: 1.0,
-											lacerate: 1.0
-									},
-							'fish' : {		neutral: 1.0,
-											fire: 0.0,
-											energy: 1.5,
-											acid: 0.5,
-											impact: 0.5,
-											lacerate: 1.0
-									},
-							'mechanical' : {neutral: 1.0,
-											fire: 0.0,
-											energy: 1.0,
-											acid: 1.5,
-											impact: 0.5,
-											lacerate: 0.0
-									},
-							'spectral' : {	neutral: 1.0,
-											fire: 0.0,
-											energy: 1.0,
-											acid: 0.0,
-											impact: 0.0,
-											lacerate: 0.0
-									},
-							'mammal' : {	neutral: 1.0,
-											fire: 1.0,
-											energy: 0.5,
-											acid: 1.5,
-											impact: 1.0,
-											lacerate: 1.0
-									},
-							'bird' : {		neutral: 1.0,
-											fire: 0.5,
-											energy: 0.5,
-											acid: 0.5,
-											impact: 1.0,
-											lacerate: 1.5
-									},
-								}",
-										
-
-# death
-	should_track_death: "bool :: false", //tracking is for achievements
-	handle_death: "def(interface {damage_type: string} collide_with) -> commands [
-						add(level.player.score,points_value),
-						if(not acquirable_item_drop_value = null,drop_acquirable_items()),
-						if(should_track_death, level.player.register_kill(me)),
-						if(me.corpse_object_type, spawn_corpse),
-						
-						death_effects( if(collide_with.damage_type in death_fx_damage_types_that_have_animations and (not death_fx_ignore_damage_type), collide_with.damage_type, death_fx_type) )
-						] asserting level.player is obj player_controlled",
-						
-	spawn_corpse: "commands :: if(corpse_object_type is string, spawn(corpse_object_type, mid_x, mid_y, facing))",
-	corpse_object_type: "string|null :: null",
-
-	death_fx_type: "string :: if(me.taxonomy in keys(death_fx_table), death_fx_table[me.taxonomy], 'medium')",
-	death_fx_ignore_damage_type: "bool :: false", //certain bosses always have the same death effects, rather than having "special" ones according to what they got damaged by.
-	death_fx_damage_types_that_have_animations: "['fire', 'acid', 'energy']",   //we don't and won't have special animations for all damage types, only for "flashy" ones like fire and such.
-	death_fx_table: "{string->string} :: {
-						'bug':			'bug', 
-						'plant':		'plant', 
-						'mushroom':		'mushroom',
-						'mammal':		'animal', 
-						'bird':			'animal', 
-						'fish':			'animal', 
-						'milgramen':	'milgramen',
-						'stone':		'medium',
-						'mechanical':	'medium',
-						'spectral':		'medium',
-					}",
-# invincibility
-	is_invincible_posthit: "bool :: if(time_last_hit and (abs(time_last_hit - level.cycle) < posthit_invicibility_period), true, false)",
-	is_invincible: "bool :: if(invincible or level.in_dialog or is_invincible_posthit, true, false)",
-
-
-
 
 #-------------------------- item drop logic --------------------------#
-	drop_item_list: "{string -> int} :: sans_undroppables(_drop_item_list)",
-	drop_item_weights: "{string -> int} :: sans_undroppables(_drop_item_weights)",
 	_drop_item_list: "{string -> int} :: {'heart_object' : 10, 'mana_cube' : 7}",
 	_drop_item_weights: "{string -> int} :: {'heart_object' : 30, 'mana_cube' : 70}",
 	drop_item_validity: "{string -> bool} :: {'heart_object' : (not level.player.hitpoints = level.player.max_hitpoints),  'mana_cube' : true }",
-	acquirable_item_drop_value: "int :: 0",  //how many of the dropped items the dying monster/thing is worth.
-	sans_undroppables: "def({string -> int} source) -> {string -> int} filter(source, drop_item_validity[key])",
-	
-	
-	choose_drop_item_nonweighted: "string :: choose(keys(drop_item_list))",  //unused but useful reference
-	choose_drop_item_weighted: "string :: search_drop_list(drop_item_weights, 0, 0, 1d(sum(values(drop_item_weights)))) ",
-	search_drop_list: "def({string -> int} thelist, int i, int tally, int target_val) -> string if(tally >= target_val, keys(thelist)[i-1], search_drop_list( thelist, i+1, tally + values(thelist)[i], target_val))",
-
-	calculate_drop_items: "def(int value_left, [string] toBeDropped) -> [string]
-			if( anything_can_still_be_dropped, calculate_drop_items(value_left - drop_item_list[picked], toBeDropped + [picked]), toBeDropped)
-				where picked = choose_drop_item_weighted
-				where anything_can_still_be_dropped = (find(values(drop_item_list), value <= value_left) != null)",
-	drop_acquirable_items: "def() -> commands if((not higher_difficulty) or 1d4=4,
-									map(calculate_drop_items(me.acquirable_item_drop_value,[]), spawn(value, me.mid_x, me.y, me.facing,[set(child.velocity_x, velocity_x/6 +1d600-300), set(child.velocity_y, velocity_y/6)])))",
-
 	
 #-------------------------- cosmetic functions --------------------------#
 	play_grabbed_cosmetics: "commands :: [play_hurt_sounds('neutral',1)]",
-
-	display_hurt_visuals: "def(interface {damage_type: string} collide_with, int amount) -> commands execute(me, 
-						[play_hurt_sounds(collide_with.damage_type, amount), if(amount > 0, hurt_flash_sequence, invincible_flash_sequence)]
-					)",
-
-	invincible_flash_sequence: "commands ::	[	flash_blue,
-												schedule(5, flash_off),
-												schedule(6, flash_blue),
-												schedule(8, flash_off)]",
-
-	hurt_flash_sequence: "commands	::	[	flash_bright,
-											schedule(3, flash_red),
-											schedule(6, flash_bright),
-											schedule(9, flash_red),
-											schedule(12, flash_bright),
-											schedule(15, flash_off)]",
-	
 
 		//these should be the material-interaction sounds of an object being damaged; wood crunching, flesh squishing, glass breaking, etc.  A certain material will make different noise depending on what hurts it, and that's what this handles - wood burning is a very different sound from wood being crushed.  By default we provide a set of sounds for fleshy objects.									
 	play_hurt_sounds: "def(string damage_type, decimal damage_amount) -> commands [if(play_object_specific_hurt_sounds(damage_type, damage_amount) != null, play_object_specific_hurt_sounds(damage_type, damage_amount),
@@ -303,23 +33,9 @@ properties: {
 								)),
 								if(should_play_pain_sfx,[play_object_specific_pain_vocalization(damage_type, damage_amount), set(_last_played_pain_sfx,level.cycle)])]
 									where should_play_pain_sfx = (level.cycle >= (_last_played_pain_sfx + 28))",
-								
-		//override this to allow an object to have its own specific material sounds
-	play_object_specific_hurt_sounds: "def(string damage_type, damage_amount) -> commands switch(damage_type, 
-									'neutral', null,
-								null)",
 	
 		//generally speaking, these sounds should not differ between damage types.	If a creature yelps in pain, it should always sound the same.  We might want it to be a matter of magnitude, though.						
-	play_object_specific_pain_vocalization: "def(string damage_type, damage_amount) -> commands null",
-
 								
-	display_posthit_invincibility_flash_sequence: "def() -> commands if(posthit_invicibility_period, 
-			map(range(me.posthit_invicibility_period/2), 'step' ,schedule(step*2, if(step%2=0,set(me.alpha,50),set(me.alpha,255))  ) ) )",
-	flash_bright: "commands :: [set(me.brightness, 1023)]",
-	flash_blue: "commands :: [set(me.red, 50),set(me.green, 50), set(me.blue, 175)]",
-	flash_red: "commands :: [set(me.red, 255),set(me.green, 100), set(me.blue, 100)]",
-	flash_off: "commands :: [set(me.brightness, 255),set(me.red, 255),set(me.green, 255), set(me.blue, 255)]",
-	
 	
 	death_effects: "def(string type) -> commands
 			if(me.underwater, splash_effect(),
@@ -384,8 +100,6 @@ properties: {
 			'wood_solid':	['ins','tnk',],
 			'metal':		['ppl','dsb',],
 		}",
-	object_tags: "[string] :: if(material_tag is [string], material_tag, ['default']) where material_tag = filter([standing_on and standing_on['material_sound']], value)",
-	tags_on: "[string] :: object_tags or unique(filter(map(tiles_at(midpoint_x, y+img_h+1), tile_tags[value.id]), value))",
 	tagged_sfx: "def(string action) -> [{keys : [string], sound : commands}] switch(action,
 		'slide', [
 			{keys: ['wood'],	   sound: sound('slide-wood'+1d13+'.wav')},
@@ -434,47 +148,7 @@ properties: {
 							'metal',	sound('collide-metal-heavy'+1d7+'.wav'),
 							'coconut',	sound('hopper-block1.wav'),
 							            sound('bump-2.wav'))",
-							
-#--------------------------  vars --------------------------#
-	time_last_hit: { type: "int", default: 0, persistent: false },
-	attributes: { type: "{string->string}", default: {}, persistent: false }, 
+	},
 
-#-------------------------- temporary vars --------------------------#
-
-	_in_solidity_fail: { type: "bool", default: false, persistent: false },
-	
-	_last_played_pain_sfx: { type: "int", default: 0, persistent: false },
-							
-},
-
-#-------------------------- collision event handling --------------------------#
-	on_start_level: "if(level.cycle < time_last_hit, set(time_last_hit, 0))",
-
-	on_outside_level: "[if(y > level.dimensions[3] and unless_we_shouldnt, add(hitpoints,-1))] where unless_we_shouldnt = if(level.player is obj player_controlled_platformer_character, not (level.player.exempt_from_dying_whilst_falling_rules_for_a_cutscene or level.player.exempt_from_dying_whilst_falling_due_to_level_portals), true)",
-
-	on_being_removed: "map(filter(spawned_children, value is obj shadow), remove_object(value))",
-
-
-	//this is meant to ensure we don't take multple instances of damage from a damage type that's a "stream" in a single frame.  If we get hit, we check for other collisions with the same kind of shot, and only take damage from the first one.
-	//we double-check it's the same collide-with area, because we DO want multiple collisions from an object for each different area; we use this on e.g. the milgram-pod to allow it to be shot out of the air by the player (needs a body area and a thrown area during the thrown anim, rather than the usual "only the thrown area" for player-spat objects).  This mechanism may be the ideal place to check for 'armored regions' on an otherwise vulnerable creature; check if we're getting a collision on both the body and the armor.
-	//TODO:  this may be unwanted on shots without a cooldown, where a "shotgun" effect of multiple hits is desired.
-on_collide_object_body: "if(arg.collide_with is obj hittable, if(not  find(   filter(arg.all_collisions, value.collide_with.type = arg.collide_with.type and value.collide_with_area = arg.collide_with_area), value.collision_index < arg.collision_index), process_collision)
-
-		//two special exceptions here besides the 'no friendly-fire' rule;
-		// evil_harmless is a special team for thrown enemies wherein they can't hurt anyone, regardless of the target's team, but also - stuff from team 'evil' won't friendly-fire them.  They can and will be hurt by any player actions, though, and any traps/neutral damage sources.
-	where process_collision = if(arg.collide_with.team != team and (not team in arg.collide_with.teams_which_wont_get_hurt_by_me) and arg.collide_with.team != 'evil_harmless' and (not (arg.collide_with.team = 'evil' and team = 'evil_harmless')), if(arg.collide_with_area in ['attack','thrown'], get_hit_by(arg.collide_with))))",
-
-#-------------------------- error condition handling --------------------------#
-on_change_solid_dimensions_fail: "fire_event('solidity_fail')",
-on_change_animation_failure: "fire_event('solidity_fail')",
-
-# if the level starts, and we're embedded in solid stuff, try moving upwards to get out of it.
-# this should catch any errors introduced by changes to solid area or handling thereof
-on_solidity_fail: "if(_in_solidity_fail, die(),
-	          [set(_in_solidity_fail, true),
-			   resolve_solid(me),
-			   set(_in_solidity_fail, false)
-			  ])",
-on_add_object_fail: "if(collide_with is obj hittable, [if(collide_with.team != team and collide_with.get_hit_by, collide_with.get_hit_by(me)), die()], die())
-	where collide_with = arg.collide_with",
+on_being_removed: "map(filter(spawned_children, value is obj shadow), remove_object(value))"
 }

--- a/data/object_prototypes/base/hittable_std.cfg
+++ b/data/object_prototypes/base/hittable_std.cfg
@@ -1,0 +1,478 @@
+# This script is for general usage, and can be used outside of Frogatto.
+
+{
+id: "hittable_std",
+prototype: ["standard_values"],
+is_strict: true,
+collide_dimensions: ["player","~enemy","~hazard"],
+
+mass: 5,
+properties: {
+#--------------------------  constants --------------------------#
+	team: "string :: 'evil'",
+	teams_which_wont_get_hurt_by_me: "[string] :: []",	//a special exemption; used on e.g. the shockwave airplane boss bomb, to keep it from killing the bridge
+	swallowable: "bool :: false",
+	is_a_flier: "bool :: false",
+	flinch_threshold: "int :: 3",
+	hurt_velocity_y: "int :: -400",
+	hurt_velocity_x: "int :: -200",
+	attack_knockback: "int :: 0",
+	attack_damage: "int :: 0",
+	attack_damage_to_player: "int :: 0",
+	damage_type: "string :: 'neutral'",  //options include fire, acid, energy
+	armor: "int :: 0",
+	posthit_invicibility_period: "int :: 0",
+	damage_cooldown: "int :: 0",
+	sourceless_damage_cooldown: "int :: 20",
+	points_value: "int :: 0",
+	
+	material_sound: "string :: 'default'",
+	
+	physical_size: "int :: 16",
+	is_player_body_part: "bool :: false",
+
+	taxonomy: "string :: 'neutral'",	//e.g. plant, bug, fish, etc.  Used for damage type reductions.
+	basic_type: "string :: me.type",
+	frogourmet_tag: "string :: me.basic_type",
+	thrown_type: "string :: me.basic_type",
+
+		#-- shot includes --#
+	deflectable_via_attacks: "bool :: if(team = 'player', false, true)",  
+	dies_upon_dealing_damage: "bool :: true",
+	is_a_shot: "bool :: false",
+	goes_through_enemy_shots: "bool :: false",
+	
+		#-- special flags for specific objects --#
+	affects_ethereal_block_triggers: "bool :: true",
+	
+#--------------------------  core behavior handlers --------------------------#	
+	get_hit_by: "def(obj hittable collide_with) -> commands execute(me, [
+						handle_special_damage_response(collide_with),
+	
+						if((collide_with.attack_damage > 0) and collide_with.hitpoints > 0 and collide_with.damage_cooldown < (level.cycle - time_last_hit),
+							[if((not is_invincible) and collide_with.attack_damage > armor,
+									[display_posthit_invincibility_flash_sequence(),
+									handle_flinch(collide_with),
+									handle_damage(collide_with),
+									set(time_last_hit, level.cycle),
+									])]),
+						
+						handle_knockback(collide_with)])",
+						
+	get_hit_sourceless: "def(string damage_type, int damage_amount) -> commands execute(me,  /*take damage and invoke the usual behavior, but without having a source object available to refer to.
+															This almost universally should be used for e.g. being stomped on, or other self-determined damage amounts (falling?).
+															It's also used for thrown damage because the throwee is dead and would (potentially) be a null reference by the time the latter collision was processed.*/
+						if((not is_invincible) and (damage_amount >= armor) and (sourceless_damage_cooldown < (level.cycle - time_last_hit)),
+								[display_posthit_invincibility_flash_sequence(),
+								handle_damage_sourceless(damage_type, damage_amount),
+								/* specifically skip flinching, because kitties don't do it.  TODO: Might be something to later reconsider. */
+								set(time_last_hit, level.cycle),
+								]))",
+
+#-------------------------- identifiers --------------------------#
+	
+	
+
+#-------------------------- generic helper functions --------------------------#
+	facing_towards_player: "bool :: facing = if(level.player.midpoint_x < self.midpoint_x, -1, 1)",
+	attempt_animation: "def(string anim_name, string fallback_anim) -> commands execute(me, if(anim_name in available_animations, set(animation, anim_name), set(animation, fallback_anim)))",
+
+
+#-------------------------- behavior handlers --------------------------#
+# anims/movement
+	handle_special_damage_response: "def(obj hittable|null collide_with) -> commands null #virtual#", //meant for unique actions upon taking damage, like losing wings.  Also for special type-based behavior that happens regardless of damage amount (such as maybe a feathered creature having its feathers burned off and effectively turning into a different, flightless enemy type).
+	handle_flinch: "def(obj hittable collide_with) -> commands
+			execute(me, if(final_damage_amount(collide_with, collide_with.attack_damage) >= flinch_threshold, if(me.is_a_flier, cause_flinch(collide_with), if(is_standing, cause_flinch(collide_with))) ))",
+	cause_flinch: "def(obj hittable|null collide_with) -> commands execute(me, [
+			add(me.velocity_x,me.hurt_velocity_x * sign(me.midpoint_x - if(collide_with, collide_with.midpoint_x, 0))), 
+			add(me.velocity_y,me.hurt_velocity_y),
+			cause_hurt_anim(collide_with)
+			])",
+	cause_hurt_anim: "def(obj hittable|null collide_with) -> commands execute(me, if('hurt' in available_animations,set(me.animation, 'hurt')))",
+
+	player_damage_response: "def(string damage_type, int amount) -> commands null",	//player objects will always do special responses to damage (like making the screen flash), besides the built-in stuff
+
+	elastic_collision: "def( obj hittable the_other_object, {multiplier: decimal, constraint: {min: decimal, max: decimal}|null} params ) -> commands
+		([set(velocity_x, radius * cos(angle)), set(velocity_y, radius * sin(angle))]
+		where angle = lib.math.angle(the_other_object, me) where radius = if(params.constraint, lib.math.constrain(params.constraint.min, params.multiplier * velocity_magnitude , params.constraint.max), params.multiplier * velocity_magnitude) )  where velocity_magnitude = hypot(velocity_x,velocity_y)",
+	
+# damage
+	//meant for applying any kind of arithmetic to the raw damage amount, based on type.
+		//this is what you overload if you want to have an exception to the damage tables (i.e. for an unusual weakness; as opposed to a usual one for a given type)
+	handle_custom_damage_type_modifications: "def(string damage_type, int amount) -> int|null null #virtual#",  
+		//only overload this if you want to completely annul the damage tables for this object (i.e. for complete immunity to all but one damage type)
+	handle_damage_type_modifications: "def(string damage_type, int amount) -> int
+		if(handle_custom_damage_type_modifications(damage_type,amount) != null,  int <- handle_custom_damage_type_modifications(damage_type,amount),
+			if(uses_custom_damage_table, int(custom_damage_table[damage_type] * amount),
+				if(me.taxonomy in keys(damage_tables), int(damage_tables[me.taxonomy][damage_type] * amount), amount
+		)))", //the neutral case automatically falls through
+	
+	uses_custom_damage_table: "bool :: false",  //cheap trick:  if you just want something to take 100% damage from all damage types, you can use this without redefining the 'custom_damage_table', which happens to just have 100% as the value for everything.
+	
+	//meant for flat, type-agnostic reductions to ALL damage.
+	handle_base_damage_reductions: "def(int amount) -> int amount #virtual#",  
+	
+	final_damage_amount: "def(interface {damage_type: string} collide_with, int damage_amount) -> int if((damage_amount < armor) or me.is_invincible, 0, handle_damage_type_modifications(collide_with.damage_type, handle_base_damage_reductions( damage_amount )))",
+	will_be_dead: "def(int damage_amount) -> bool ((me.hitpoints - damage_amount) <= 0)",
+
+	
+	handle_damage_sourceless: "def(string damage_type, int amount) -> commands execute(me,[if(will_be_dead(dmg), handle_death({damage_type:damage_type})), add(me.hitpoints, -dmg), display_hurt_visuals({damage_type:damage_type},dmg), player_damage_response(damage_type,dmg)]) where dmg = final_damage_amount({damage_type:damage_type}, amount)",
+	handle_damage: "def(obj hittable collide_with) -> commands execute(me,[if(will_be_dead(dmg), handle_death(collide_with)), add(me.hitpoints, - dmg), display_hurt_visuals(collide_with,dmg),player_damage_response(collide_with.damage_type,dmg)]) where dmg = final_damage_amount(collide_with, attack_damage_amount) where attack_damage_amount = if((me is obj player_controlled) and collide_with.attack_damage_to_player, collide_with.attack_damage_to_player, collide_with.attack_damage)",
+
+	handle_knockback: "def(obj hittable collide_with) -> commands execute(me,add(velocity_x, behind_or_in_front * collide_with.attack_knockback) where behind_or_in_front = sign(me.mid_x - collide_with.mid_x) )",
+
+	custom_damage_table: "{neutral:decimal, fire:decimal, energy:decimal, acid:decimal, impact:decimal, lacerate:decimal} ::
+							{	neutral: 1.0,
+								fire: 1.0,
+								energy: 1.0,
+								acid: 1.0,
+								impact: 1.0,
+								lacerate: 1.0
+							}",
+
+	damage_tables: "{ string -> {neutral:decimal, fire:decimal, energy:decimal, acid:decimal, impact:decimal, lacerate:decimal} } ::
+						{	
+							'bug' : {		neutral: 1.0,
+											fire: 0.75,
+											energy: 1.0,
+											acid: 1.25,
+											impact: 2.0,
+											lacerate: 0.25
+									},
+							'plant' : {		neutral: 1.0,
+											fire: 1.0,
+											energy: 0.5,
+											acid: 0.25,
+											impact: 0.0,
+											lacerate: 0.5
+									},
+							'mushroom' : {	neutral: 1.0,
+											fire: 1.0,
+											energy: 1.5,
+											acid: 0.0,
+											impact: 0.0,
+											lacerate: 1.0
+									},
+							'stone' : {		neutral: 1.0,
+											fire: 0.0,
+											energy: 0.1,
+											acid: 2.0,
+											impact: 1.0,
+											lacerate: 0.0
+									},
+							'milgramen' : {	neutral: 1.0,
+											fire: 0.75,
+											energy: 1.0,
+											acid: 0.75,
+											impact: 1.0,
+											lacerate: 1.0
+									},
+							'fish' : {		neutral: 1.0,
+											fire: 0.0,
+											energy: 1.5,
+											acid: 0.5,
+											impact: 0.5,
+											lacerate: 1.0
+									},
+							'mechanical' : {neutral: 1.0,
+											fire: 0.0,
+											energy: 1.0,
+											acid: 1.5,
+											impact: 0.5,
+											lacerate: 0.0
+									},
+							'spectral' : {	neutral: 1.0,
+											fire: 0.0,
+											energy: 1.0,
+											acid: 0.0,
+											impact: 0.0,
+											lacerate: 0.0
+									},
+							'mammal' : {	neutral: 1.0,
+											fire: 1.0,
+											energy: 0.5,
+											acid: 1.5,
+											impact: 1.0,
+											lacerate: 1.0
+									},
+							'bird' : {		neutral: 1.0,
+											fire: 0.5,
+											energy: 0.5,
+											acid: 0.5,
+											impact: 1.0,
+											lacerate: 1.5
+									},
+								}",
+										
+
+# death
+	should_track_death: "bool :: false", //tracking is for achievements
+	handle_death: "def(interface {damage_type: string} collide_with) -> commands [
+						add(level.player.score,points_value),
+						if(not acquirable_item_drop_value = null,drop_acquirable_items()),
+						if(should_track_death, level.player.register_kill(me)),
+						if(me.corpse_object_type, spawn_corpse),
+						
+						death_effects( if(collide_with.damage_type in death_fx_damage_types_that_have_animations and (not death_fx_ignore_damage_type), collide_with.damage_type, death_fx_type) )
+						] asserting level.player is obj player_controlled",
+						
+	spawn_corpse: "commands :: if(corpse_object_type is string, spawn(corpse_object_type, mid_x, mid_y, facing))",
+	corpse_object_type: "string|null :: null",
+
+	death_fx_type: "string :: if(me.taxonomy in keys(death_fx_table), death_fx_table[me.taxonomy], 'medium')",
+	death_fx_ignore_damage_type: "bool :: false", //certain bosses always have the same death effects, rather than having "special" ones according to what they got damaged by.
+	death_fx_damage_types_that_have_animations: "['fire', 'acid', 'energy']",   //we don't and won't have special animations for all damage types, only for "flashy" ones like fire and such.
+	death_fx_table: "{string->string} :: {
+						'bug':			'bug', 
+						'plant':		'plant', 
+						'mushroom':		'mushroom',
+						'mammal':		'animal', 
+						'bird':			'animal', 
+						'fish':			'animal', 
+						'milgramen':	'milgramen',
+						'stone':		'medium',
+						'mechanical':	'medium',
+						'spectral':		'medium',
+					}",
+# invincibility
+	is_invincible_posthit: "bool :: if(time_last_hit and (abs(time_last_hit - level.cycle) < posthit_invicibility_period), true, false)",
+	is_invincible: "bool :: if(invincible or level.in_dialog or is_invincible_posthit, true, false)",
+
+
+
+
+#-------------------------- item drop logic --------------------------#
+	drop_item_list: "{string -> int} :: sans_undroppables(_drop_item_list)",
+	drop_item_weights: "{string -> int} :: sans_undroppables(_drop_item_weights)",
+	_drop_item_list: "{string -> int} :: {'heart_object' : 10, 'mana_cube' : 7}",
+	_drop_item_weights: "{string -> int} :: {'heart_object' : 30, 'mana_cube' : 70}",
+	drop_item_validity: "{string -> bool} :: {'heart_object' : (not level.player.hitpoints = level.player.max_hitpoints),  'mana_cube' : true }",
+	acquirable_item_drop_value: "int :: 0",  //how many of the dropped items the dying monster/thing is worth.
+	sans_undroppables: "def({string -> int} source) -> {string -> int} filter(source, drop_item_validity[key])",
+	
+	
+	choose_drop_item_nonweighted: "string :: choose(keys(drop_item_list))",  //unused but useful reference
+	choose_drop_item_weighted: "string :: search_drop_list(drop_item_weights, 0, 0, 1d(sum(values(drop_item_weights)))) ",
+	search_drop_list: "def({string -> int} thelist, int i, int tally, int target_val) -> string if(tally >= target_val, keys(thelist)[i-1], search_drop_list( thelist, i+1, tally + values(thelist)[i], target_val))",
+
+	calculate_drop_items: "def(int value_left, [string] toBeDropped) -> [string]
+			if( anything_can_still_be_dropped, calculate_drop_items(value_left - drop_item_list[picked], toBeDropped + [picked]), toBeDropped)
+				where picked = choose_drop_item_weighted
+				where anything_can_still_be_dropped = (find(values(drop_item_list), value <= value_left) != null)",
+	drop_acquirable_items: "def() -> commands if((not higher_difficulty) or 1d4=4,
+									map(calculate_drop_items(me.acquirable_item_drop_value,[]), spawn(value, me.mid_x, me.y, me.facing,[set(child.velocity_x, velocity_x/6 +1d600-300), set(child.velocity_y, velocity_y/6)])))",
+
+	
+#-------------------------- cosmetic functions --------------------------#
+	play_grabbed_cosmetics: "commands :: [play_hurt_sounds('neutral',1)]",
+
+	display_hurt_visuals: "def(interface {damage_type: string} collide_with, int amount) -> commands execute(me, 
+						[play_hurt_sounds(collide_with.damage_type, amount), if(amount > 0, hurt_flash_sequence, invincible_flash_sequence)]
+					)",
+
+	invincible_flash_sequence: "commands ::	[	flash_blue,
+												schedule(5, flash_off),
+												schedule(6, flash_blue),
+												schedule(8, flash_off)]",
+
+	hurt_flash_sequence: "commands	::	[	flash_bright,
+											schedule(3, flash_red),
+											schedule(6, flash_bright),
+											schedule(9, flash_red),
+											schedule(12, flash_bright),
+											schedule(15, flash_off)]",
+	
+
+		//these should be the material-interaction sounds of an object being damaged; wood crunching, flesh squishing, glass breaking, etc.  A certain material will make different noise depending on what hurts it, and that's what this handles - wood burning is a very different sound from wood being crushed.  By default we provide a set of sounds for fleshy objects.									
+	play_hurt_sounds: "def(string damage_type, decimal damage_amount) -> commands [if(play_object_specific_hurt_sounds(damage_type, damage_amount) != null, play_object_specific_hurt_sounds(damage_type, damage_amount),
+								if(damage_amount > 0,
+									switch(damage_type,
+										'bite', sound('hurt-bite.wav'),
+										'stab', sound('hurt-stab'+1d2+'.wav'),
+										'slash', sound('hurt-slash'+1d3+'.wav'),
+										'organic-bludgeon', sound('hurt-organic-bludgeon.wav'),
+										'neutral', null,
+										'electricity', sound('hurt-electricity.wav', 0.5)
+									),
+									switch(me.taxonomy,
+										'plant', sound('resist-plant.wav'),
+										'neutral', null
+									),
+								)),
+								if(should_play_pain_sfx,[play_object_specific_pain_vocalization(damage_type, damage_amount), set(_last_played_pain_sfx,level.cycle)])]
+									where should_play_pain_sfx = (level.cycle >= (_last_played_pain_sfx + 28))",
+								
+		//override this to allow an object to have its own specific material sounds
+	play_object_specific_hurt_sounds: "def(string damage_type, damage_amount) -> commands switch(damage_type, 
+									'neutral', null,
+								null)",
+	
+		//generally speaking, these sounds should not differ between damage types.	If a creature yelps in pain, it should always sound the same.  We might want it to be a matter of magnitude, though.						
+	play_object_specific_pain_vocalization: "def(string damage_type, damage_amount) -> commands null",
+
+								
+	display_posthit_invincibility_flash_sequence: "def() -> commands if(posthit_invicibility_period, 
+			map(range(me.posthit_invicibility_period/2), 'step' ,schedule(step*2, if(step%2=0,set(me.alpha,50),set(me.alpha,255))  ) ) )",
+	flash_bright: "commands :: [set(me.brightness, 1023)]",
+	flash_blue: "commands :: [set(me.red, 50),set(me.green, 50), set(me.blue, 175)]",
+	flash_red: "commands :: [set(me.red, 255),set(me.green, 100), set(me.blue, 100)]",
+	flash_off: "commands :: [set(me.brightness, 255),set(me.red, 255),set(me.green, 255), set(me.blue, 255)]",
+	
+	
+	death_effects: "def(string type) -> commands
+			if(me.underwater, splash_effect(),
+
+			(switch(type,
+					'none', null,  //for creatures that specifically want to die without showing anything
+					
+					/*these are a set of effects based on the type of creature dying*/
+					'bug', [vfx('die_cloud_puffy'), sound('death-crunch'+1d2+'.wav')],
+					'mushroom', [vfx('die_cloud_evaporative'), sound('death-crunch'+1d2+'.wav')],
+					'plant', [vfx('die_cloud_evaporative'), sound('Death-Plant-Short'+1d5+'.wav')],
+					'animal', [vfx('die_cloud'), sound('death-crunch'+1d2+'.wav'), spawn_gibs('bone_straight',1d2), spawn_gibs('bone_skull',1)],
+					'milgramen', if(victim_is_big,	repeat_fx('die_cloud',10,5,50,70, sound('Milgramen-Explode'+1d5+'.wav')),
+					 								[vfx('die_cloud'), sound('Milgramen-Explode'+1d5+'.wav')]),
+					 								
+
+					/*a set of effects based on the damage source; elsewhere in hittable these actually overrule the creature-type*/
+					'fire', if(victim_is_big,		[repeat_fx('die_cloud_fire',5,4,30,30,sound('death-acid'+1d5+'.wav'))],
+													[vfx('die_cloud_fire'), sound('death-acid'+1d5+'.wav')]),
+					'acid', if(victim_is_big,		[repeat_fx('die_cloud_acid_small',40,1,50,50,null), sound('death-acid-bubbly1.wav')],
+													[repeat_fx('die_cloud_acid_small',10,6,30,30,null), sound('death-acid-bubbly1.wav')]),
+					'energy', [repeat_fx('die_cloud_electric_medium',1d2+5,4,20,30, null),repeat_fx('electric_spark1',3+1d3,1,60,60,null), sound('death-acid'+1d5+'.wav')],
+
+					
+					/*generic recurring effects for miscellaneous things - often not actually enemies*/
+					'small', repeat_fx('die_cloud_small',5,4,10,10, null),
+					'medium', repeat_fx('die_cloud_medium',5,4,20,30, null),
+					'large', repeat_fx('die_cloud',5,10,50,70, sound('splat.ogg')),
+					
+					/*special custom effects for bosses*/
+					'mushroom-boss', repeat_fx('die_cloud_evaporative',40,10,70,120, sound('death-crunch'+1d2+'.wav')),
+					'moth-boss', repeat_fx('die_cloud_puffy',40,5,70,120, sound('death-crunch'+1d2+'.wav')),
+			)
+			where repeat_fx = def(string obj_type, int count, int delay, int spread_x, int spread_y, commands do_sound) -> commands spawn('particle_system_holder', me.mid_x, me.mid_y, if(1d2=2,-1,1), 
+				execute(child, map(range(count),schedule(value*delay, [child.set_time_to_live(count*(delay+1)), vfx_spread(obj_type,spread_x,spread_y), do_sound ]))))
+			
+			
+			) where vfx = def(string obj_type) -> commands spawn(obj_type, me.mid_x, me.mid_y, if(1d2=2,-1,1)))
+			where vfx_spread = def(string obj_type, int spread_x, int spread_y) -> commands spawn(obj_type, me.mid_x + 1d(spread_x) - 1d(spread_x), me.mid_y  + 1d(spread_y) - 1d(spread_y), if(1d2=2,-1,1))
+			where victim_is_big = me.physical_size >= 48
+			",
+	
+	spawn_gibs: "def(string variation_type, int count) -> commands map([0]*count, spawn('bouncing_debris_chunk',x+1d10, y+1d10, if(1d2=2,1,-1), [add(child.variations, [variation_type]),child.init_vel('burst')]))",
+
+	splash_effect: "def() -> commands if(me.underwater and me.water_bounds,
+					[if(abs(me.water_bounds[1] - me.midpoint_y) > 40,
+						spawn('water_splash_underwater_big', me.mid_x, me.mid_y, if(1d2=2,me.facing,-me.facing)),
+						spawn('water_splash', me.midpoint_x, me.water_bounds[1]+10, if(1d2=2,me.facing,-me.facing))),
+					sound('water-enter.ogg'), ])",
+					
+#-------------------------- sfx for material-interactions --------------------------#
+	tile_tags: "{string -> string} :: //Twist around the data structure, so that each tile mnemonic is the key to a list of keys to the lists it's in.
+		fold(
+			map(flatten(values(tags)), 'tla',
+				{(tla): string <- find(keys(tags), 'key', tla in tags[key])} ),
+			a+b)
+		where tags = {
+			'wood': 		['fbr','acn','act','ast','isb','fnt','int',],
+			'foliage':		['ngs',],
+			'dirt':			['nrk','frg',],
+			'stone':		['crk','dbk','cbk',],
+			'wood_solid':	['ins','tnk',],
+			'metal':		['ppl','dsb',],
+		}",
+	object_tags: "[string] :: if(material_tag is [string], material_tag, ['default']) where material_tag = filter([standing_on and standing_on['material_sound']], value)",
+	tags_on: "[string] :: object_tags or unique(filter(map(tiles_at(midpoint_x, y+img_h+1), tile_tags[value.id]), value))",
+	tagged_sfx: "def(string action) -> [{keys : [string], sound : commands}] switch(action,
+		'slide', [
+			{keys: ['wood'],	   sound: sound('slide-wood'+1d13+'.wav')},
+			{keys: ['foliage'],	sound: sound('slide-foliage'+1d10+'.wav')},
+			{keys: ['dirt'],	   sound: sound('slide-dirt'+1d4+'.wav')},
+			{keys: ['stone'],	  sound: sound('slide-stone'+1d10+'.wav')},
+			{keys: ['wood_solid'], sound: sound('slide-wood-solid'+1d5+'.wav')},
+			{keys: ['metal'],	  sound: sound('slide-metal'+1d9+'.wav')},
+			{keys: ['padding'],	sound: sound('footstep-slide-padding'+1d4+'.wav')},
+			{keys: ['plastic'], sound: sound('footstep-slide-watercooler'+1d6+'.wav')},
+			{keys: ['default'], sound: sound('slide-dirt'+1d4+'.wav')},
+			],
+		'jump', [
+			{keys: ['wood'],	   sound: sound('jump-wood'+1d10+'.wav',0.7)},
+			{keys: ['foliage'],	sound: sound('jump-foliage'+1d8+'.wav')},
+			{keys: ['padding'],	sound: sound('footstep-jump-padding'+1d7+'.wav')},
+			{keys: ['plastic'], sound: sound('footstep-jump-watercooler'+1d6+'.wav')},
+			{keys: ['dirt'],	   sound: sound('jump-dirt'+1d9+'.wav')},
+			{keys: ['stone'],	  sound: sound('footstep-run-stone'+1d8+'.wav')},
+			{keys: ['wood_solid'], sound: sound('jump-wood-solid'+1d3+'.wav',0.6)},
+			{keys: ['metal'],	  sound: sound('footstep-run-metal'+1d5+'.wav',0.6)},
+			{keys: ['default'],	sound: sound('JumpSoft.ogg')},
+			],
+		'footfall', [
+			{keys: ['wood'],	   sound: sound('footstep-'+run+'wood'+if(running,1d10,1d7)+'.wav',if(running,0.7,1.0))},
+			{keys: ['foliage'],	sound: sound('footstep-'+run+'foliage'+if(running,1d9,1d6)+'.wav')},
+			{keys: ['plastic'], sound: sound('footstep-run-watercooler'+1d5+'.wav')},
+			{keys: ['dirt'],	   sound: sound('footstep-'+run+'dirt'+if(running,1d9,1d10)+'.wav')},
+			{keys: ['stone'],	  sound: sound('footstep-'+run+'stone'+if(running,1d8,1d10)+'.wav')},
+			{keys: ['padding'],	sound: sound('footstep-'+run+'padding'+if(running,1d7,1d7)+'.wav')},
+			{keys: ['wood_solid'], sound: sound('footstep-'+run+'wood-solid'+if(running,1d7,1d8)+'.wav',0.6)},
+			{keys: ['metal'],	  sound: sound('footstep-'+run+'metal'+if(running,1d5,1d5)+'.wav',0.8)},
+			{keys: ['default'],	sound: sound('footstep'+1d4+'.wav')},
+			] where run = if(animation in ['run'],'run-','') where running = (animation in ['run']) 
+		)",
+
+
+	choose_sfx: "def(string action) -> commands
+		if(snd, snd.sound) where snd =  {keys: [string], sound: commands} <- find(sfx, 'effect', find(tags + ['default'], 'tag', tag in effect.keys)) where sfx = tagged_sfx(action), tags = tags_on",
+		
+		
+			
+	impact_cloud_silent: "def(int new_x, int new_y, string size) -> commands if(size = 'small', spawn('impact_cloud_small',new_x,new_y,1), spawn('impact_cloud',new_x,new_y,1))",
+	impact_cloud: "def(int new_x, int new_y, string size) -> commands [impact_cloud_silent(new_x,new_y,size),play_impact_sound]",
+	play_impact_sound: "commands :: switch(material_sound,
+							'metal',	sound('collide-metal-heavy'+1d7+'.wav'),
+							'coconut',	sound('hopper-block1.wav'),
+							            sound('bump-2.wav'))",
+							
+#--------------------------  vars --------------------------#
+	time_last_hit: { type: "int", default: 0, persistent: false },
+	attributes: { type: "{string->string}", default: {}, persistent: false }, 
+
+#-------------------------- temporary vars --------------------------#
+
+	_in_solidity_fail: { type: "bool", default: false, persistent: false },
+	
+	_last_played_pain_sfx: { type: "int", default: 0, persistent: false },
+							
+},
+
+#-------------------------- collision event handling --------------------------#
+	on_start_level: "if(level.cycle < time_last_hit, set(time_last_hit, 0))",
+
+	on_outside_level: "[if(y > level.dimensions[3] and unless_we_shouldnt, add(hitpoints,-1))] where unless_we_shouldnt = if(level.player is obj player_controlled_platformer_character, not (level.player.exempt_from_dying_whilst_falling_rules_for_a_cutscene or level.player.exempt_from_dying_whilst_falling_due_to_level_portals), true)",
+
+	on_being_removed: "map(filter(spawned_children, value is obj shadow), remove_object(value))",
+
+
+	//this is meant to ensure we don't take multple instances of damage from a damage type that's a "stream" in a single frame.  If we get hit, we check for other collisions with the same kind of shot, and only take damage from the first one.
+	//we double-check it's the same collide-with area, because we DO want multiple collisions from an object for each different area; we use this on e.g. the milgram-pod to allow it to be shot out of the air by the player (needs a body area and a thrown area during the thrown anim, rather than the usual "only the thrown area" for player-spat objects).  This mechanism may be the ideal place to check for 'armored regions' on an otherwise vulnerable creature; check if we're getting a collision on both the body and the armor.
+	//TODO:  this may be unwanted on shots without a cooldown, where a "shotgun" effect of multiple hits is desired.
+on_collide_object_body: "if(arg.collide_with is obj hittable, if(not  find(   filter(arg.all_collisions, value.collide_with.type = arg.collide_with.type and value.collide_with_area = arg.collide_with_area), value.collision_index < arg.collision_index), process_collision)
+
+		//two special exceptions here besides the 'no friendly-fire' rule;
+		// evil_harmless is a special team for thrown enemies wherein they can't hurt anyone, regardless of the target's team, but also - stuff from team 'evil' won't friendly-fire them.  They can and will be hurt by any player actions, though, and any traps/neutral damage sources.
+	where process_collision = if(arg.collide_with.team != team and (not team in arg.collide_with.teams_which_wont_get_hurt_by_me) and arg.collide_with.team != 'evil_harmless' and (not (arg.collide_with.team = 'evil' and team = 'evil_harmless')), if(arg.collide_with_area in ['attack','thrown'], get_hit_by(arg.collide_with))))",
+
+#-------------------------- error condition handling --------------------------#
+on_change_solid_dimensions_fail: "fire_event('solidity_fail')",
+on_change_animation_failure: "fire_event('solidity_fail')",
+
+# if the level starts, and we're embedded in solid stuff, try moving upwards to get out of it.
+# this should catch any errors introduced by changes to solid area or handling thereof
+on_solidity_fail: "if(_in_solidity_fail, die(),
+	          [set(_in_solidity_fail, true),
+			   resolve_solid(me),
+			   set(_in_solidity_fail, false)
+			  ])",
+on_add_object_fail: "if(collide_with is obj hittable, [if(collide_with.team != team and collide_with.get_hit_by, collide_with.get_hit_by(me)), die()], die())
+	where collide_with = arg.collide_with",
+}


### PR DESCRIPTION
My idea is to make it easier for other module creators to use the Frogatto's hittable.cfg code. I'm in the process of making my module standalone from Frogatto, and hittable.cfg was probably the hardest one to make work. (Because it depends on Frogatto's files/objects in several places.)

Everything that was specific to Frogatto was kept in hittable, while everything that is general has been put in hittable_std. Functions which both required by another general function _and_ depended on Frogatto got turned into virtual functions for hittable_std. (And then overloaded in hittable, to keep from losing functionality.) I have kept a few examples from Frogatto in hittable_std.cfg to make it easier to use.

Although I have not tested Frogatto extensively, everything seems to run. (I can't say that for my game, yet, but at least hittable stopped throwing errors.)
