### PR TITLE
Translation fixes, add inventory items to gettext template.

### DIFF
--- a/data/objects/gui-components/inventory-screen/map_pane.cfg
+++ b/data/objects/gui-components/inventory-screen/map_pane.cfg
@@ -10,7 +10,7 @@ properties: {
 			relative_y: -200,
 			use_absolute_screen_coordinates: true,
 			zorder: int<-lib.json.get_document_map('data/zorder.cfg').overlaid_gui_dialog_gui_element,
-			txt: level.title,
+			txt: translate(level.title),
 			font: 'door_label_dark',
 			align: 'center',
 			parent: me,

--- a/data/objects/playable/frogatto_playable.cfg
+++ b/data/objects/playable/frogatto_playable.cfg
@@ -213,7 +213,7 @@ properties: {
 	do_post_victory_transport: "def(string target_level, string target_obj) -> commands execute(me,[
 									set(me.hitpoints, me.max_hitpoints),
 									standard_victory_music,
-									title('Victory!',200),
+									title(~Victory!~,200),
 									do_cinematic_float(
 									[
 									def() schedule(1, sinusoidal_transition({period:90, _init_theta:0.0, _length_theta:1.0, addend:2, coefficient:1, obj:level, aspect:'zoom'})),
@@ -228,7 +228,7 @@ properties: {
 	do_post_victory_without_transport: "def([function() -> commands] post_landing_todos) -> commands execute(me,[
 					set(me.hitpoints, me.max_hitpoints),
 					standard_victory_music,
-					title('Victory!',200),
+					title(~Victory!~,200),
 					do_cinematic_float(
 					[def() schedule(119, remove_control_lock('cinematic_float')),
 					def() schedule(60, sinusoidal_transition({period:100, _init_theta:1.0, _length_theta:1.0, addend:1, coefficient:1, obj:level, aspect:'zoom'})),

--- a/utils/make-pot.sh
+++ b/utils/make-pot.sh
@@ -40,8 +40,9 @@ grep -Hn --exclude-dir=".svn" "~[^~][^~]*~" ../data/level/*/*.cfg | \
 	sed -e 's/\\\\n/\\n/g' | \
 	sed -ne ":A;s/\([a-zA-Z0-9/\._-]*:[0-9]*\):[^~]*~\([^~][^~]*\)~/\n#: \1\nmsgid \"\2\"\nmsgstr \"\"\n\1:/;tA;s/\n\([a-zA-Z0-9/\._-]*:[0-9]*\):[^\n]*//;p"
 # find marked strings ~...~ in data files; files in data/*/experimental are ignored
-grep -Hnr --exclude-dir=".svn" --exclude-dir="experimental" "~[^~][^~]*~" ../data/objects/ ../data/object_prototypes/ | \
-    grep -v "collide_dimensions:"  | \
+grep -Hnr --exclude-dir=".svn" --exclude-dir="experimental" "~[^~][^~]*~" \
+	../data/objects/ ../data/object_prototypes/ ../data/items.cfg | \
+	grep -v "collide_dimensions:"  | \
 	sed -e 's/\\\\n/\\n/g' | \
 	sed -ne ":A;s/\([a-zA-Z0-9/\._-]*:[0-9]*\):[^~]*~\([^~][^~]*\)~/\n#: \1\nmsgid \"\2\"\nmsgstr \"\"\n\1:/;tA;s/\n\([a-zA-Z0-9/\._-]*:[0-9]*\):[^\n]*//;p"
 # find marked strings _("...") in source files


### PR DESCRIPTION
Add inventory items to translation template, enable translation of meandering map title and re-enable translation of victory message that has been removed from first boss level now.