### PR TITLE
Fixed a bug where the bomb particle will stay after swallowing the bomb 

### DIFF
--- a/data/objects/enemies/bugs/moth_bomber_bomb.cfg
+++ b/data/objects/enemies/bugs/moth_bomber_bomb.cfg
@@ -38,6 +38,9 @@
 										force_death()
 									)
 								)",
+							
+	on_been_grabbed: "
+		if(my_particles, remove_object(my_particles))",						
 	
 	on_die:  "[
 		spawn('explosion_big_harmful',midpoint_x,midpoint_y-32,facing),


### PR DESCRIPTION
Bug:
![image](https://user-images.githubusercontent.com/67684800/113388942-6e981880-938f-11eb-8aef-da06c367f276.png)

(This little star is a bomb particle)

Now it shouldn't happen because I remove the particle every time a bomb is ``on_been_grabbed``