### PR TITLE
Fixed issues regarding super-shooting-plant misaligned shots

### DIFF
--- a/data/objects/enemies/plants/super_shooting_plant.cfg
+++ b/data/objects/enemies/plants/super_shooting_plant.cfg
@@ -25,7 +25,7 @@ on_end_chargeup_anim: "if(anim_repeat > chargeup_repeat,
 on_end_shoot_anim: "animation('normal')",
 
 on_shoot: 	"[
-				spawn('super_shooting_plant.pollen_ball_huge', mid_x, mid_y + if(not upside_down, 0, 40), {facing: facing, velocity_y: 500*upside_down-500, upside_down: upside_down}),
+				spawn('super_shooting_plant.pollen_ball_huge', mid_x, if(down = 1, mid_y - 40, mid_y + 40), {facing: facing, velocity_y: 500*upside_down-500, upside_down: upside_down}),
 				sound('pollen-shot.wav'),
 			]",
 


### PR DESCRIPTION
After 0dec18406d6e30e9fd93d2ab61cedbc9f452c63b commit, normal (not upside down) super shooting plants started shooting 'backwards'. This PR should fix it.

(Note: This video has some problems with Firefox, but you should be able to watch it in Chrome and maybe other browsers)
Video of the bug before and after it was fixed:


https://user-images.githubusercontent.com/67684800/115747931-0046e480-a396-11eb-95e2-3488ec22abab.mp4

This is not directly connected to #404, but the issue should be closed since it was fixed by 0dec18406d6e30e9fd93d2ab61cedbc9f452c63b