### PR TITLE
Hide secrets in minimap

### DIFF
--- a/data/objects/gui-components/inventory-screen/minimap_controller.cfg
+++ b/data/objects/gui-components/inventory-screen/minimap_controller.cfg
@@ -15,6 +15,16 @@ properties: {
 	level_scale: "decimal <- 1.0 / (240.0 / (level.dimensions[2] - level.dimensions[0])) //A good default is 25. Currently sets the scale to about half of the screen width.",
 	
 	icons: { type: "[custom_obj]", default: [] },
+
+	_world_to_canvas_x: "def (int x) -> decimal (x - level.dimensions[0] - level_scale)/level_scale",
+	_world_to_canvas_y: "def (int y) -> decimal (y - level.dimensions[1] - level_scale)/level_scale",
+	_canvas_range: "def (decimal min, decimal max) -> [int]
+		range(lib.math.floor(min), lib.math.ceil(max) + 1)",
+	_secret_areas: "def () -> [[int, int, int, int]] [
+	  [int, int, int, int] <- [passage._x_bound, passage._x2_bound, passage._y_bound, passage._y2_bound]
+	  | passage <- level.chars,
+	  passage is obj secret_passage_controller | obj nonsecret_passage_controller
+	]",
 },
 
 on_create: "[
@@ -88,6 +98,17 @@ on_set_background: "[
 				c.fill(),
 			] | px <- range(lWidth),
 			    py <- range(lHeight)
+		] + [
+			[
+				[
+					c.set_source_rgba(0,0,0,
+						(40d2)/(40*1.47) //subtle noise
+					),
+					c.rectangle(px,py,1,1),
+					c.fill(),
+				] | px <- _canvas_range(_world_to_canvas_x(area[0]), _world_to_canvas_x(area[1])),
+				    py <- _canvas_range(_world_to_canvas_y(area[2]), _world_to_canvas_y(area[3]))
+			] | area <- _secret_areas()
 		] + [
 			c.set_source_rgba(1,0,0,1),
 		] /*+ [[ //Draw hittable objects in red.


### PR DESCRIPTION
Currently, when the secrets open up, the minimap updates to reflect the newly walkable area. This is a bare-minimum change to obscure `secret_passage_controller`s and `nonsecret_passage_controller`s.