### PR TITLE
Store inventory panel index in player properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Frogatto & Friends
-[![Latest release](https://img.shields.io/github/v/tag/frogatto/frogatto?label=Latest%20release)](https://github.com/frogatto/frogatto/releases) [![Anura](https://img.shields.io/badge/Engine-Anura-informational)](https://github.com/anura-engine/anura) [![Discord](https://img.shields.io/discord/225816341737766912?label=Discord&logo=Discord&logoColor=white)](https://discord.gg/duSVAX3) ![Matrix](https://img.shields.io/matrix/frogatto:matrix.org?label=Matrix)
+[![Latest release](https://img.shields.io/github/v/tag/frogatto/frogatto?label=Latest%20release)](https://github.com/frogatto/frogatto/releases) [![Anura](https://img.shields.io/badge/Engine-Anura-informational)](https://github.com/anura-engine/anura) [![Discord](https://img.shields.io/discord/225816341737766912?label=Discord&logo=Discord&logoColor=white)](https://discord.gg/duSVAX3) [![Matrix](https://img.shields.io/matrix/frogatto:matrix.org?label=Matrix)](https://matrix.to/#/!CBBwOSRlKVFiheKBpP:matrix.org)
 
 **Frogatto & Friends** is an action-adventure game, starring a certain quixotic frog.  We're trying to push 2D platforming, pixel-art, and music into uncharted territory; we hope you like the results!
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Frogatto & Friends
-[![Latest release](https://img.shields.io/github/v/tag/frogatto/frogatto?label=Latest%20release)](https://github.com/frogatto/frogatto/releases) [![Anura](https://img.shields.io/badge/Engine-Anura-informational)](https://github.com/anura-engine/anura) [![Discord](https://img.shields.io/discord/225816341737766912?label=Discord&logo=Discord&logoColor=white)](https://discord.gg/duSVAX3) [![Matrix](https://img.shields.io/matrix/frogatto:matrix.org?label=Matrix&style=plastic)]
+[![Latest release](https://img.shields.io/github/v/tag/frogatto/frogatto?label=Latest%20release)](https://github.com/frogatto/frogatto/releases) [![Anura](https://img.shields.io/badge/Engine-Anura-informational)](https://github.com/anura-engine/anura) [![Discord](https://img.shields.io/discord/225816341737766912?label=Discord&logo=Discord&logoColor=white)](https://discord.gg/duSVAX3) ![Matrix](https://img.shields.io/matrix/frogatto:matrix.org?label=Matrix)
 
 **Frogatto & Friends** is an action-adventure game, starring a certain quixotic frog.  We're trying to push 2D platforming, pixel-art, and music into uncharted territory; we hope you like the results!
 

--- a/data/object_prototypes/base/player_controlled.cfg
+++ b/data/object_prototypes/base/player_controlled.cfg
@@ -504,7 +504,7 @@ properties: {
 	last_toggled_ability: { type: "int", default: -10 },
 	last_toggled_secondary_item: { type: "int", default: -10 },
 
-
+    last_focused_panel_index: { type: "int", default: 0 }, // for storing inventory pane index
 
 	toggle_ability_by_category: "def( enum { left, right } direction, ItemCategory category ) -> commands
 				if( size(the_item_list) > 0,

--- a/data/objects/gui-components/inventory-screen/inventory_screen_controller_2.cfg
+++ b/data/objects/gui-components/inventory-screen/inventory_screen_controller_2.cfg
@@ -178,7 +178,11 @@ properties: {
 	]",	
 	
 	process_individual_keypresses: "commands :: map(active_inputs, switch(value,
-		enum close,				if(cycle > 1, die()),
+		enum close,				if(cycle > 1,
+                                [
+									set(frogatto.last_focused_panel_index, focused_panel_index),
+                                    die(),
+                                ]),
 		enum pane_left,			slide_to_relative_panel(-1),
 		enum pane_right,		slide_to_relative_panel(1),
 		enum pane_left,			slide_to_relative_panel(-1),
@@ -266,11 +270,12 @@ on_create: "[ //TODO: restore Frogatto's cycle to what it was before the menu
 	if(not pause_level, set(frogatto.control_lock, [])),
 
 	add_all_panels,
-		
+	
+    set(focused_panel_index, frogatto.last_focused_panel_index), //restore currently open panel index in the player    
+    
 	add_scroll_arrows(),
 	
-		
-	;snap_to_panel( if(idx, idx, 0 ) where idx = panel_index_by_type('bestiary_pane') ),
+	;snap_to_panel(focused_panel_index),
 ]",
 
 //To auto-reload this, add spawn('inventory_screen_controller_2', 0,0,1), to frogatto's on_process. (I can't figure out how to re-spawn the object from this event.) Use only if pause_level is set to true!


### PR DESCRIPTION
Currently, the inventory always open at the bestiary page. This change stores the most recent panel index in `player.last_focused_panel_index`, and restores it upon opening the inventory.