### PR TITLE
Fix coasting coconuts

### DIFF
--- a/data/object_prototypes/base/throwable_projectile.cfg
+++ b/data/object_prototypes/base/throwable_projectile.cfg
@@ -66,7 +66,7 @@ on_process_on_back: "[add(_on_back_count,1),if(_on_back_count > (on_back_duratio
 on_collide_object_body: "",
 
 
-
+on_collide_feet: "animation('thrown')",
 
 
 }


### PR DESCRIPTION
Now, if something bumps into them, they should get knocked off the tree
instead of hovering.