### PR TITLE
Added flags for modern GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BASE_CXXFLAGS += -O2
 endif
 
 # Initial compiler options, used before CXXFLAGS and CPPFLAGS.
-BASE_CXXFLAGS += -g -fno-inline-functions -fthreadsafe-statics -Wnon-virtual-dtor -Werror -Wignored-qualifiers -Wformat -Wswitch
+BASE_CXXFLAGS += -g -fno-inline-functions -fthreadsafe-statics -Wnon-virtual-dtor -Wignored-qualifiers -Wformat -Wswitch -Wno-narrowing
 
 # Compiler include options, used after CXXFLAGS and CPPFLAGS.
 INC := $(shell pkg-config --cflags x11 sdl glu glew SDL_image libpng zlib)


### PR DESCRIPTION
This (plus `-std=c++11`) is needed to compile with org.freedesktop.Sdk 21.08