### PR TITLE
made save statues interactable

### DIFF
--- a/data/objects/props-interactive/misc/save_statue.cfg
+++ b/data/objects/props-interactive/misc/save_statue.cfg
@@ -185,6 +185,8 @@ on_process: "[
 				)
 			]",
 
+on_interact: "if((me.cycle - _last_triggered > 60), activate)", /* give enough time for the "The game has been saved" text to disappear */
+		
 animation: [
 	{
 		"@base": true,
@@ -195,6 +197,7 @@ animation: [
 	{
 		id: "normal",
 		rect: [1,1,30,30],
+    	interact_area: [0,1,31,30],
 		frames: 1,
 		duration: -1,
 	},


### PR DESCRIPTION
Save statues now save your game when interacting using the up key. Fixes #594 