### PR TITLE
made milgram more fire resistant

### DIFF
--- a/data/objects/enemies/bosses/milgram.cfg
+++ b/data/objects/enemies/bosses/milgram.cfg
@@ -19,6 +19,16 @@ properties: {
 	points_value: 10000,
 	armor: "40",
 	taxonomy: "TaxonomyType :: enum neutral",
+	custom_damage_table: "{
+		enum neutral: 1.0,
+		enum fire: 0.3,
+		enum energy: 1.0,
+		enum arcane: 1.0,
+		enum acid: 0.0,
+		enum impact: 1.0,
+		enum impale: 1.0,
+		enum lacerate: 1.0
+	}",
 	team: "'evil'",
 	attack_damage: "if(higher_difficulty,3,2)",
 	


### PR DESCRIPTION
Added a `custom_damage_table` to milgram, reducing the amount of damage he takes from fire. Fixes #630  