### PR TITLE
Make shadow_effect_controller visible in level editor

### DIFF
--- a/data/objects/effects/scene-shaders/shadow_effect_controller.cfg
+++ b/data/objects/effects/scene-shaders/shadow_effect_controller.cfg
@@ -3,7 +3,7 @@
 	is_strict: true,
 	always_active: true,
 	hidden_in_game: true,
-	zorder: "@include data/zorder.cfg:shadow_overlay",
+	zorder: "@include data/zorder.cfg:in_front_of_everything",
 	scale: 8,
 
 	editor_info: {


### PR DESCRIPTION
After placing a shadow_effect_controller in a level, it becomes invisible unless directly moused over, making it frustrating to find again.