### PR TITLE
Add knocking sound to Elder's canestomp

### DIFF
--- a/data/objects/props-interactive/npcs/town_elder_npc.cfg
+++ b/data/objects/props-interactive/npcs/town_elder_npc.cfg
@@ -100,6 +100,7 @@ animation: [
 		duration: 7,
 		frames: 12,
 		frames_per_row: 4,
+		events:"25:caneland",
 	},
 ],
 }


### PR DESCRIPTION
Many of the Elder's animations produce sounds when the cane hits the ground. This adds sound to the `canestomp` animation where the elder specifically strikes the ground with his cane.