### PR TITLE
First item to select for an inventory pane is now actually pane specic

### DIFF
--- a/data/objects/gui-components/inventory-screen/inventory_pane.cfg
+++ b/data/objects/gui-components/inventory-screen/inventory_pane.cfg
@@ -205,7 +205,7 @@ object_type: [
 		on_create: "if(first_target, 
 			select(first_target), 
 			schedule(1, fire_event('create'))
-		) where first_target = find(level.active_chars, 
+		) where first_target = find(item_chars, 
 			value is obj inventory_pane.item_anchor)",
 		
 		animation: [{


### PR DESCRIPTION
First item to select for an inventory pane is now actually pane specific, and not just the first item_anchor found on a level.
Resolves https://github.com/frogatto/frogatto/issues/640