### PR TITLE
Added function `choppa_disable` to player to turn the `choppa` cheat off. The inverse of `choppa`.

### DIFF
--- a/data/objects/playable/frogatto_playable.cfg
+++ b/data/objects/playable/frogatto_playable.cfg
@@ -424,7 +424,8 @@ properties: {
 	
 		//activate a weird loophole where you don't run out of upward momentum whilst jumping;  you jump up, and as long as you keep holding the button, it's just up up and up.
 	choppa: "set(_jump_cheat,true)",
-	
+	choppa_disable: "set(_jump_cheat,false)",
+
 		//kill every enemy in the level.
 	smite: "map(filter(level.chars, value is obj hittable), if(value.team = 'evil', value.force_death()))",
 


### PR DESCRIPTION
It's not going to be used often, I just got annoyed editing the save file every time in order to turn it off.