### PR TITLE
Super ability icons are specific to graphic cell

### DIFF
--- a/data/objects/gui-components/hud-components/ability_display.cfg
+++ b/data/objects/gui-components/hud-components/ability_display.cfg
@@ -158,14 +158,14 @@
 				where is_this_ability_enabled = def(int ability_index) -> bool player.should_make_hud_graphic_look_enabled_for_this_item(item_info(ability_index).id)
 				where item_info = def(int offset) -> class inventory_item
 				(
-					player.item_info( player.nth_item_away_from_current_item_of_category(normalized_index, item_category) )
-
-					where item_category = if(not player.is_super_attack_completely_viable_besides_mana_and_cooldowns,
-						if(not player.underwater,
+					player.item_info( given_item )
+					where given_item = player.nth_item_away_from_current_item_of_category(normalized_index, item_category)
+					where item_category = if(player.is_super_attack_completely_viable_besides_mana_and_cooldowns and normalized_index = 0,
+						enum super_ability,
+						if(player.underwater,
+							enum underwater_ability,
 							enum primary_ability,
-							enum underwater_ability
-						),					
-						enum super_ability
+						),						
 					)
 
 					/*

--- a/data/objects/gui-components/hud-components/ability_display.cfg
+++ b/data/objects/gui-components/hud-components/ability_display.cfg
@@ -157,24 +157,25 @@
 			]
 				where is_this_ability_enabled = def(int ability_index) -> bool player.should_make_hud_graphic_look_enabled_for_this_item(item_info(ability_index).id)
 				where item_info = def(int offset) -> class inventory_item
-				(
-					player.item_info( given_item )
-					where given_item = player.nth_item_away_from_current_item_of_category(normalized_index, item_category)
-					where item_category = if(player.is_super_attack_completely_viable_besides_mana_and_cooldowns and normalized_index = 0,
-						enum super_ability,
-						if(player.underwater,
-							enum underwater_ability,
-							enum primary_ability,
-						),						
+					(
+						player.item_info(current_item)
+						where current_item = player.nth_item_away_from_current_item_of_category(normalized_index, item_category)
+						where item_category = 
+							if(player.underwater,
+								enum underwater_ability,							
+							 	if(player.is_super_attack_completely_viable_besides_mana_and_cooldowns_for_ability(current_super_item),
+									enum super_ability,
+									enum primary_ability,
+								),
+							)
+						
+						where current_super_item = player.nth_item_away_from_current_item_of_category(normalized_index, enum super_ability)
+						
+						/*
+							There's a little bit of 'special logic' here in the where clause - this is intended to take our offset (i.e. which of the 5 graphical cells we could be looking at), and change the values from `[0, 1, 2, 3, 4]`, to being `[-2, -1, 0, 1, 2]`.  0 is meant to specially represent the -current- ability the player has selected.
+						*/
+						where normalized_index =  offset - index(graphic_cells, graphic)
 					)
-
-					/*
-						There's a little bit of 'special logic' here in the where clause - this is intended to take our offset (i.e. which of the 5 graphical cells we could be looking at), and change the values from `[0, 1, 2, 3, 4]`, to being `[-2, -1, 0, 1, 2]`.  0 is meant to specially represent the -current- ability the player has selected.
-					*/
-					where normalized_index =  offset - index(graphic_cells, graphic)
-				)
-
-				
 		) where si_uniforms = super_indicator.shader.uniform_commands asserting super_indicator.shader
 	",
 	

--- a/data/objects/playable/frogatto_playable.cfg
+++ b/data/objects/playable/frogatto_playable.cfg
@@ -642,10 +642,10 @@ properties: {
 			)",
 
 	is_super_attack_completely_viable_besides_mana_and_cooldowns: "bool ::
-		is_super_attack_completely_viable_besides_mana_and_cooldowns_for_item(current_ability)
+		is_super_attack_completely_viable_besides_mana_and_cooldowns_for_ability(current_ability)
 	",
 
-	is_super_attack_completely_viable_besides_mana_and_cooldowns_for_item: "def(InventoryItemType ability) -> bool
+	is_super_attack_completely_viable_besides_mana_and_cooldowns_for_ability: "def(InventoryItemType ability) -> bool
 		stomach_contents_would_allow_super_attack
 		and
 		has_super_pendant_for_ability(ability)

--- a/data/objects/playable/frogatto_playable.cfg
+++ b/data/objects/playable/frogatto_playable.cfg
@@ -642,9 +642,13 @@ properties: {
 			)",
 
 	is_super_attack_completely_viable_besides_mana_and_cooldowns: "bool ::
+		is_super_attack_completely_viable_besides_mana_and_cooldowns_for_item(current_ability)
+	",
+
+	is_super_attack_completely_viable_besides_mana_and_cooldowns_for_item: "def(InventoryItemType ability) -> bool
 		stomach_contents_would_allow_super_attack
 		and
-		has_super_pendant_for_ability(current_ability)
+		has_super_pendant_for_ability(ability)
 	",
 
 	has_super_pendant_for_ability: "def(InventoryItemType regular_ability) -> bool


### PR DESCRIPTION
Instead of showing all icons as super/normal based on the player's currently selected ability, the super icon is determined for each item individually.
Fixes https://github.com/frogatto/frogatto/issues/600

Provided the player has:
* fire breath
* bouncy fire
* energy shots
* acid shots
* fire honing sphere
* acid honing sphere

The abilities now look like:
![image](https://github.com/frogatto/frogatto/assets/104121665/0d106230-6cf1-44f2-b7b7-6683a1f9fbe0)

instead of:
![image](https://github.com/frogatto/frogatto/assets/104121665/6af1caa6-b3c4-4299-a82f-3dee7cf81382)
