### PR TITLE
Show coin counter in shops.

### DIFF
--- a/data/level/Forest/prosperas-workshop.cfg
+++ b/data/level/Forest/prosperas-workshop.cfg
@@ -15,6 +15,22 @@
 			"y": 224
 		},
 		{
+			"_uuid": "5db522f9122841c4917009f93d53d359",
+			"current_frame": "normal",
+			"custom": true,
+			"label": "show_coin_hud",
+			"on_start_level": "[frogatto.gui_gold_display.set_perma_show(true)] where frogatto = (obj frogatto_playable <- level.player)",
+			"property_data": {
+				"_x2_bound": 714,
+				"_x_bound": 464,
+				"_y2_bound": 426,
+				"_y_bound": 176
+			},
+			"type": "level_controller",
+			"x": 564,
+			"y": 276
+		},
+		{
 			"_uuid": "d4f85312d55047b08c8319c60e9a3455",
 			"current_frame": "normal",
 			"custom": true,

--- a/data/level/Forest/tempo-village-house-store.cfg
+++ b/data/level/Forest/tempo-village-house-store.cfg
@@ -538,6 +538,23 @@
 			"type": "store_item",
 			"x": -243,
 			"y": 257
+		},
+		{
+			"_uuid": "438d123f394b411793bf0703ec731046",
+			"current_frame": "normal",
+			"custom": true,
+			"face_right": false,
+			"label": "show_coin_hud",
+			"on_start_level": "[frogatto.gui_gold_display.set_perma_show(true)] where frogatto = (obj frogatto_playable <- level.player)",
+			"property_data": {
+				"_x2_bound": -918,
+				"_x_bound": -1168,
+				"_y2_bound": 298,
+				"_y_bound": 48
+			},
+			"type": "level_controller",
+			"x": -1068,
+			"y": 148
 		}
 	],
 	"dimensions": [-640,-448,1663,599],

--- a/data/level/Seaside/chopple-shop-interior.cfg
+++ b/data/level/Seaside/chopple-shop-interior.cfg
@@ -164,13 +164,11 @@
 			"_uuid": "b538bbafa3994f60bcf60b3129f866ff",
 			"current_frame": "normal",
 			"custom": true,
-			"face_right": 1,
 			"label": "_5092ca794242",
-			"time_in_frame": 0,
-			"type": "store_item",
 			"property_data": {
 				"settable_item_id": "@eval enum item_heart_container"
 			},
+			"type": "store_item",
 			"x": 360,
 			"y": 303
 		},
@@ -179,10 +177,10 @@
 			"current_frame": "normal",
 			"custom": true,
 			"label": "_5092ca42",
-			"type": "store_item",
 			"property_data": {
 				"settable_item_id": "@eval enum item_tongue_extension"
 			},
+			"type": "store_item",
 			"x": 208,
 			"y": 310
 		},
@@ -291,10 +289,10 @@
 			"current_frame": "normal",
 			"custom": true,
 			"label": "_444bfbff",
-			"type": "store_item",
 			"property_data": {
 				"settable_item_id": "@eval enum item_lesser_mana_talisman"
 			},
+			"type": "store_item",
 			"x": 721,
 			"y": 342
 		},
@@ -303,18 +301,34 @@
 			"current_frame": "normal",
 			"custom": true,
 			"label": "_67af979",
-			"type": "store_item",
 			"property_data": {
 				"settable_item_id": "@eval enum item_health_potion"
 			},
+			"type": "store_item",
 			"x": 880,
 			"y": 343
+		},
+		{
+			"_uuid": "5db522f9122841c4917009f93d53d359",
+			"current_frame": "normal",
+			"custom": true,
+			"label": "show_coin_hud",
+			"on_start_level": "[frogatto.gui_gold_display.set_perma_show(true)] where frogatto = (obj frogatto_playable <- level.player)",
+			"property_data": {
+				"_x2_bound": 714,
+				"_x_bound": 464,
+				"_y2_bound": 426,
+				"_y_bound": 176
+			},
+			"type": "level_controller",
+			"x": 564,
+			"y": 276
 		}
 	],
 	"dimensions": [-288,-64,1503,704],
 	"id": "chopple-shop-interior.cfg",
 	"music": "NeoShop.ogg",
-	"palettes": ["interior_seaside_yellow","chrome_to_brass"],
+	"palettes": ["chrome_to_brass","interior_seaside_yellow"],
 	"preloads": "",
 	"segment_height": 0,
 	"segment_width": 0,

--- a/data/objects/gui-components/hud-components/hud_gold_display.cfg
+++ b/data/objects/gui-components/hud-components/hud_gold_display.cfg
@@ -2,16 +2,22 @@
 	id: "hud_gold_display",
 	prototype: ["hud_component"],
 	hidden_in_game: true,
-	
 
 	properties: {
+		perma_show: {type: "bool", default: false},
 		set_text: "def(string text) -> commands [set(txt, text), fire_event(me, 'create')]",
 		txt: {type: "string", default: "+"},
 		size: "2",
 		font: "string :: 'numbers_gold_enormous'",
 		align: "'right'",
 		
-		
+		set_perma_show: "def(bool show) -> commands [
+			set(perma_show, show),
+			if(show,
+				set(mid_y, native_position.y + vertical_full_offset),
+			)	
+		]",		
+	
 		comparison_point_for_coins: { type: "int", default: 0 },
 		last_changed_coins: { type: "int", default: -500 },
 		display_timeout: "decimal :: 100",
@@ -25,6 +31,7 @@
 		poll_for_coin_changes: "if(comparison_point_for_coins != level.player.coins,
 									[
 										set(comparison_point_for_coins, level.player.coins),
+										// The animation would be better of if re-written using `animate`, and a timer trigger event for when the coin display should slide out - al0f
 										set(last_changed_coins, me.cycle),
 									]
 								)",
@@ -35,8 +42,6 @@
 		
 		coin_icon: { type: "obj hud_gold_display.coin_icon", init: "object('hud_gold_display.coin_icon', x, y, {parent: me})", },
 	},
-
-	on_create: "[text(txt, font, size, align), add_object(coin_icon), set(coin_icon.relative_x, 60), set(coin_icon.relative_y, 8)]",
 
 	on_window_resize: "set(xy, [new_pos.x, new_pos.y])
 		where new_pos = {x:screen_w - 66*2,y:50}
@@ -49,8 +54,12 @@
 			me.set_text( str(level.player.coins) + '×')
 			;
 			set(text_alpha, alpha_proxy),
-			poll_for_coin_changes,
-			set_vertical_pos,
+			if(not perma_show,
+				[
+					poll_for_coin_changes,
+					set_vertical_pos,
+				]
+			)
 		])
 	]",
 	
@@ -59,7 +68,6 @@
 		id: "coin_icon",
 		prototype: ["hud_component"],
 
-		
 		on_end_anim: "animation('normal')",
 		
 		animation: {
@@ -71,5 +79,6 @@
 			frames: 6,
 			duration: 6,
 		},
+		
 	}
 }

--- a/data/objects/playable/frogatto_playable.cfg
+++ b/data/objects/playable/frogatto_playable.cfg
@@ -24,7 +24,8 @@ load_variations: "fat",
 properties: {						
 #-------------------------- constructor/destructor logic --------------------------#
 	common_frogatto_specific_constructor_commands: "	[
-		set_up_gui
+		set_up_gui,
+		gui_gold_display.set_perma_show(false)
 		;
 		gui_boss_progress_display.reset(),
 		set(boss_list, []),


### PR DESCRIPTION
Added the 'set_perma_show' function to the coin display. Once set to true, the coin counter remains visible until the next level load. Additionally added level controllers to Chopple's shop, Prospera's shop and Tempo Village's shop to make the hud permanently visible upon level load.

Fixes https://github.com/frogatto/frogatto/issues/628